### PR TITLE
feat: Implement Messenger "Hide Typing" bypass via source-code replac…

### DIFF
--- a/dist/background.js
+++ b/dist/background.js
@@ -1,0 +1,91 @@
+/**
+ * Ghostify Background Service Worker
+ * 
+ * 1. Removes CSP headers from Facebook/Messenger using declarativeNetRequest
+ * 2. Registers content scripts dynamically using chrome.scripting API
+ */
+
+// =========================================================================
+// CSP HEADER REMOVAL
+// This is the KEY to making inline script injection work!
+// =========================================================================
+
+async function removeCSPHeaders() {
+    const hostPatterns = [
+        "^https?://.*\\.facebook\\.com/.*",
+        "^https?://.*\\.messenger\\.com/.*"
+    ];
+
+    try {
+        const existingRules = await chrome.declarativeNetRequest.getDynamicRules();
+        const existingRuleIds = existingRules.map(r => r.id);
+
+        const newRules = hostPatterns.map((pattern, index) => ({
+            id: index + 1,
+            priority: 1,
+            action: {
+                type: "modifyHeaders",
+                responseHeaders: [
+                    { header: "Content-Security-Policy", operation: "remove" },
+                    { header: "Content-Security-Policy-Report-Only", operation: "remove" }
+                ]
+            },
+            condition: {
+                regexFilter: pattern,
+                resourceTypes: ["main_frame", "sub_frame"]
+            }
+        }));
+
+        await chrome.declarativeNetRequest.updateDynamicRules({
+            removeRuleIds: existingRuleIds,
+            addRules: newRules
+        });
+    } catch (e) {
+    }
+}
+
+async function registerMessengerPatch() {
+    try {
+        try {
+            await chrome.scripting.unregisterContentScripts({
+                ids: ['ghostify-messenger-patch']
+            });
+        } catch (e) {
+        }
+
+        await chrome.scripting.registerContentScripts([{
+            id: 'ghostify-messenger-patch',
+            js: ['js/messenger_patch.js'],
+            matches: [
+                'https://www.messenger.com/*',
+                'https://web.facebook.com/*',
+                'https://www.facebook.com/*',
+                '*://*.messenger.com/*',
+                '*://*.facebook.com/*'
+            ],
+            runAt: 'document_start',
+            world: 'MAIN'
+        }]);
+    } catch (e) {
+    }
+}
+
+chrome.runtime.onInstalled.addListener(() => {
+    removeCSPHeaders();
+    registerMessengerPatch();
+});
+
+chrome.runtime.onStartup.addListener(() => {
+    removeCSPHeaders();
+    registerMessengerPatch();
+});
+
+removeCSPHeaders();
+registerMessengerPatch();
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message.type === 'GHOSTIFY_PING') {
+        sendResponse({ status: 'alive' });
+    }
+    return true;
+});

--- a/dist/config/patterns.json
+++ b/dist/config/patterns.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.1",
+    "version": "1.0.3",
     "killSwitch": [],
     "patterns": {
         "igTyping": [

--- a/dist/css/popup.css
+++ b/dist/css/popup.css
@@ -142,22 +142,22 @@ body {
     transition: all 0.2s ease;
 }
 
-input:checked + .track {
+input:checked+.track {
     background: #dc2626;
     box-shadow: 0 0 12px rgba(220, 38, 38, 0.5);
 }
 
-input:checked + .track:before {
+input:checked+.track:before {
     transform: translateX(18px);
     background: #fff;
 }
 
-input:disabled + .track {
+input:disabled+.track {
     background: rgba(255, 255, 255, 0.04);
     cursor: not-allowed;
 }
 
-input:disabled + .track:before {
+input:disabled+.track:before {
     background: rgba(255, 255, 255, 0.15);
 }
 
@@ -203,8 +203,13 @@ input:disabled + .track:before {
 }
 
 @keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
+    0% {
+        transform: rotate(0deg);
+    }
+
+    100% {
+        transform: rotate(360deg);
+    }
 }
 
 /* Tooltip */
@@ -256,4 +261,29 @@ input:disabled + .track:before {
 .footer span {
     font-size: 10px;
     color: rgba(255, 255, 255, 0.2);
+}
+
+/* Always On Badge */
+.always-on-badge {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    background: rgba(34, 197, 94, 0.2);
+    color: #22c55e;
+    border-radius: 50%;
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.always-on-note {
+    font-size: 9px;
+    color: rgba(34, 197, 94, 0.8);
+    background: rgba(34, 197, 94, 0.1);
+    padding: 2px 6px;
+    border-radius: 4px;
+    margin-left: 6px;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
 }

--- a/dist/js/ghost.js
+++ b/dist/js/ghost.js
@@ -12,7 +12,7 @@
 
     let SETTINGS = {
         igTyping: true, igSeen: true, igStory: true,
-        msgTyping: false, msgSeen: true, msgStory: true
+        msgTyping: true, msgSeen: true, msgStory: true
     };
 
     const isDebugMode = () => localStorage.getItem('GHOSTIFY_DEBUG') === 'true';
@@ -286,7 +286,7 @@
     };
 
 
-    console.log('👻 Ghostify v1.0.0 Active');
+    console.log('👻 Ghostify v1.0.2 Active');
     if (isDebugMode()) {
         console.log('👻 Ghostify Active - Debug Mode ON');
         console.log('   To disable: localStorage.removeItem("GHOSTIFY_DEBUG")');

--- a/dist/js/messenger_patch.js
+++ b/dist/js/messenger_patch.js
@@ -1,0 +1,214 @@
+(function () {
+    'use strict';
+    const isMessenger = window.location.hostname.includes('messenger.com') ||
+        window.location.hostname.includes('facebook.com');
+    if (!isMessenger) return;
+    if (window.__GHOSTIFY_MESSENGER_PATCH__) return;
+    window.__GHOSTIFY_MESSENGER_PATCH__ = true;
+
+    window.__GHOSTIFY_SETTINGS__ = window.__GHOSTIFY_SETTINGS__ || {
+        msgTyping: true
+    };
+
+    window.addEventListener('message', (event) => {
+        if (event.source !== window) return;
+        if (event.data.type === 'GHOSTIFY_SETTINGS_UPDATE') {
+            window.__GHOSTIFY_SETTINGS__ = event.data.settings;
+        }
+    });
+
+    window.__ghostify_noop__ = function () { };
+
+    window.__ghostifyFnCache__ = window.__ghostifyFnCache__ || {};
+
+    function getFunctionBody(fnString) {
+        return fnString.slice(fnString.indexOf('{') + 1, fnString.lastIndexOf('}')) || '';
+    }
+
+    function getFunctionParams(fnString) {
+        const noComments = fnString.replace(/((\/\/.*$)|(\/\*[\s\S]*?\*\/))/gm, '');
+        const paramString = noComments.slice(noComments.indexOf('(') + 1, noComments.indexOf(')'));
+        const params = paramString.match(/([^\s,]+)/g);
+        return params || [];
+    }
+
+    function recreateFunctionFromSource(fnString) {
+        const body = getFunctionBody(fnString);
+        const params = getFunctionParams(fnString);
+        const fnId = 'ghostify_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+        const scriptContent = `window.__ghostifyFnCache__["${fnId}"] = function(${params.join(', ')}) { ${body} }`;
+        const script = document.createElement('script');
+        try {
+            script.appendChild(document.createTextNode(scriptContent));
+        } catch (e) {
+            script.text = scriptContent;
+        }
+        const head = document.head || document.documentElement;
+        head.appendChild(script);
+        head.removeChild(script);
+        const recreatedFn = window.__ghostifyFnCache__[fnId];
+        delete window.__ghostifyFnCache__[fnId];
+        return recreatedFn;
+    }
+
+    function wrapFunction(originalFn, wrapper) {
+        const wrapped = function (...args) {
+            return wrapper.call(this, originalFn, args);
+        };
+        try {
+            Object.getOwnPropertyNames(originalFn).forEach(prop => {
+                if (prop.startsWith('__')) {
+                    Object.defineProperty(wrapped, prop, {
+                        value: originalFn[prop],
+                        writable: false,
+                        enumerable: false,
+                        configurable: true
+                    });
+                }
+            });
+        } catch (e) { }
+        return wrapped;
+    }
+
+    const sourceReplacements = {};
+    const exportCallbacks = {};
+    const processedModules = new Set();
+
+    function registerSourceReplacement(moduleName, transformer) {
+        sourceReplacements[moduleName] = sourceReplacements[moduleName] || [];
+        sourceReplacements[moduleName].push(transformer);
+    }
+
+    function registerExportCallback(moduleName, callback) {
+        exportCallbacks[moduleName] = exportCallbacks[moduleName] || [];
+        exportCallbacks[moduleName].push(callback);
+    }
+
+    registerSourceReplacement('MAWSecureTypingState', (source) => {
+        if (window.__GHOSTIFY_SETTINGS__?.msgTyping) {
+            return source.replaceAll('sendChatStateFromComposer', 'window.__ghostify_noop__');
+        } else {
+            return source;
+        }
+    });
+
+    registerExportCallback('LSSendTypingIndicator', (factoryArgs) => {
+        const moduleObj = factoryArgs[4];
+        if (!moduleObj || !moduleObj.exports) return;
+        const exports = moduleObj.exports;
+        if (exports.default && typeof exports.default === 'function') {
+            const original = exports.default;
+            exports.default = wrapFunction(original, function (origFn, args) {
+                if (window.__GHOSTIFY_SETTINGS__?.msgTyping) {
+                    if (args.length >= 3) args[2] = false;
+                }
+                return origFn.apply(this, args);
+            });
+        }
+    });
+
+    registerExportCallback('LSSendTypingIndicatorStoredProcedure', (factoryArgs) => {
+        const moduleObj = factoryArgs[4];
+        if (!moduleObj || !moduleObj.exports) return;
+        const exports = moduleObj.exports;
+        if (exports.default && typeof exports.default === 'function') {
+            const original = exports.default;
+            exports.default = wrapFunction(original, function (origFn, args) {
+                if (window.__GHOSTIFY_SETTINGS__?.msgTyping) {
+                    if (args.length >= 3) args[2] = false;
+                }
+                return origFn.apply(this, args);
+            });
+        }
+    });
+
+    function applySourceReplacements(factory, moduleName) {
+        for (const [pattern, transformers] of Object.entries(sourceReplacements)) {
+            if (moduleName.includes(pattern)) {
+                let source = factory.toString();
+                let modified = false;
+                for (const transformer of transformers) {
+                    const newSource = transformer(source);
+                    if (newSource !== source) {
+                        source = newSource;
+                        modified = true;
+                    }
+                }
+                if (modified) {
+                    try {
+                        const recreated = recreateFunctionFromSource(source);
+                        if (typeof recreated === 'function') {
+                            return recreated;
+                        }
+                    } catch (e) {
+                    }
+                }
+            }
+        }
+        return factory;
+    }
+
+    function applyExportCallbacks(factoryArgs, moduleName) {
+        for (const [pattern, callbacks] of Object.entries(exportCallbacks)) {
+            if (moduleName.includes(pattern)) {
+                for (const callback of callbacks) {
+                    try {
+                        callback(factoryArgs);
+                    } catch (e) {
+                    }
+                }
+            }
+        }
+    }
+
+    function shouldProcessModule(moduleName) {
+        return Object.keys(sourceReplacements).some(p => moduleName.includes(p)) ||
+            Object.keys(exportCallbacks).some(p => moduleName.includes(p));
+    }
+
+    function setupModuleInterceptor() {
+        let originalDefine = window.__d;
+
+        const createProxy = (target) => {
+            return new Proxy(target, {
+                apply: (fn, thisArg, args) => {
+                    const moduleName = args[0];
+                    if (typeof moduleName === 'string' && !processedModules.has(moduleName)) {
+                        if (shouldProcessModule(moduleName)) {
+                            processedModules.add(moduleName);
+                            const originalFactory = args[2];
+                            let factory = applySourceReplacements(originalFactory, moduleName);
+                            const needsExportCallback = Object.keys(exportCallbacks).some(p => moduleName.includes(p));
+                            if (needsExportCallback) {
+                                const patchedFactory = factory;
+                                factory = function (...factoryArgs) {
+                                    const result = patchedFactory.apply(this, factoryArgs);
+                                    applyExportCallbacks(factoryArgs, moduleName);
+                                    return result;
+                                };
+                            }
+                            args[2] = factory;
+                        }
+                    }
+                    return fn.apply(thisArg, args);
+                }
+            });
+        };
+
+        if (window.__d) {
+            if (window.__d.toString().indexOf('__d_stub') !== -1) {
+                delete window.__d;
+            } else {
+                originalDefine = createProxy(window.__d);
+            }
+        }
+
+        Object.defineProperty(window, '__d', {
+            get: function () { return originalDefine; },
+            set: function (newValue) { originalDefine = createProxy(newValue); },
+            configurable: true
+        });
+    }
+
+    setupModuleInterceptor();
+})();

--- a/dist/js/popup.js
+++ b/dist/js/popup.js
@@ -2,7 +2,7 @@ const DEFAULT_SETTINGS = {
     igTyping: true,
     igSeen: true,
     igStory: true,
-    msgTyping: false,
+    msgTyping: true,
     msgSeen: true,
     msgStory: true
 };
@@ -12,6 +12,7 @@ const ELEMENT_MAP = {
     'ig-typing': 'igTyping',
     'ig-seen': 'igSeen',
     'ig-story': 'igStory',
+    // msg-typing removed - always on
     'msg-seen': 'msgSeen',
     'msg-story': 'msgStory'
 };
@@ -90,7 +91,7 @@ function saveSettings() {
         igTyping: document.getElementById('ig-typing')?.checked ?? true,
         igSeen: document.getElementById('ig-seen')?.checked ?? true,
         igStory: document.getElementById('ig-story')?.checked ?? true,
-        msgTyping: false, // (not supported yet pi)
+        msgTyping: true, // Always on - can't be toggled
         msgSeen: document.getElementById('msg-seen')?.checked ?? true,
         msgStory: document.getElementById('msg-story')?.checked ?? true
     };

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,11 +1,13 @@
 {
     "manifest_version": 3,
     "name": "Ghostify | Hide Seen, Typing & Story Views",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Control your visibility on Instagram & Facebook/Messenger. Hide typing indicators, read receipts, and story views.",
     "author": "Hendrizzzz",
     "permissions": [
-        "storage"
+        "storage",
+        "scripting",
+        "declarativeNetRequest"
     ],
     "host_permissions": [
         "*://*.instagram.com/*",
@@ -13,6 +15,9 @@
         "*://*.facebook.com/*",
         "https://raw.githubusercontent.com/*"
     ],
+    "background": {
+        "service_worker": "background.js"
+    },
     "action": {
         "default_popup": "popup.html",
         "default_title": "Ghostify - Privacy Controls"
@@ -51,7 +56,8 @@
     "web_accessible_resources": [
         {
             "resources": [
-                "config/patterns.json"
+                "config/patterns.json",
+                "js/messenger_patch.js"
             ],
             "matches": [
                 "*://*.instagram.com/*",

--- a/dist/popup.html
+++ b/dist/popup.html
@@ -49,10 +49,9 @@
             Messenger / Facebook
         </div>
         <div class="card">
-            <div class="row disabled">
-                <span class="row-label">Hide Typing</span>
-                <label class="switch"><input type="checkbox" id="msg-typing" disabled><span
-                        class="track"></span></label>
+            <div class="row">
+                <span class="row-label">Hide Typing <span class="always-on-note">Always On</span></span>
+                <span class="always-on-badge">✓</span>
             </div>
             <div class="row">
                 <span class="row-label">Hide Seen</span>


### PR DESCRIPTION
…ement (v1.0.2)

- Implement robust Messenger "Hide Typing" using source-code replacement of `MAWSecureTypingState`.
- Add [background.js](cci:7://file:///c:/Users/hendrizzzz/Desktop/Ghostify/dist/background.js:0:0-0:0) service worker to remove CSP headers (requires `declarativeNetRequest` permission) to allow script injection.
- Add [messenger_patch.js](cci:7://file:///c:/Users/hendrizzzz/Desktop/Ghostify/dist/js/messenger_patch.js:0:0-0:0) injected via `chrome.scripting` API at `document_start`.
- UI: Update popup to show Messenger "Hide Typing" as "Always On" (due to technical limitation of source replacement).
- Config: Improve [content.js](cci:7://file:///c:/Users/hendrizzzz/Desktop/Ghostify/dist/js/content.js:0:0-0:0) to prioritize local config for offline support while allowing remote updates.
- Bump version to 1.0.2.