### PR TITLE
Add View Once survey link to popup

### DIFF
--- a/dist/css/popup.css
+++ b/dist/css/popup.css
@@ -420,7 +420,7 @@ input:checked:active + .track::before {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 10px;
+    gap: 12px;
     height: 34px;
     padding: 0 14px;
     color: #5a5856;
@@ -431,6 +431,15 @@ input:checked:active + .track::before {
     letter-spacing: 0.03em;
 }
 
+.footer-links {
+    display: inline-flex;
+    align-items: center;
+    min-width: 0;
+    gap: 6px;
+    white-space: nowrap;
+}
+
+.footer-link,
 .support-link {
     position: relative;
     color: #68615f;
@@ -440,9 +449,15 @@ input:checked:active + .track::before {
     text-decoration: none;
     text-decoration-thickness: 1px;
     text-underline-offset: 3px;
-    white-space: nowrap;
 }
 
+.footer-separator {
+    color: #3f3c3b;
+    font-weight: 500;
+}
+
+.footer-link:hover,
+.footer-link:focus-visible,
 .support-link:hover,
 .support-link:focus-visible {
     color: #b8b0ae;
@@ -450,10 +465,12 @@ input:checked:active + .track::before {
     text-decoration: underline;
 }
 
+.footer-link:focus-visible,
 .support-link:focus-visible {
     box-shadow: 0 0 0 2px rgba(229, 9, 20, 0.65);
 }
 
+.footer-link::after,
 .support-link::after {
     content: attr(data-tooltip);
     position: absolute;
@@ -479,6 +496,7 @@ input:checked:active + .track::before {
     transition: none;
 }
 
+.footer-link::before,
 .support-link::before {
     content: "";
     position: absolute;
@@ -497,6 +515,21 @@ input:checked:active + .track::before {
     transition: none;
 }
 
+.survey-link::after {
+    right: auto;
+    left: -88px;
+    width: 220px;
+}
+
+.survey-link::before {
+    right: auto;
+    left: calc(50% - 4px);
+}
+
+.footer-link:hover::after,
+.footer-link:focus-visible::after,
+.footer-link:hover::before,
+.footer-link:focus-visible::before,
 .support-link:hover::after,
 .support-link:focus-visible::after,
 .support-link:hover::before,

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Ghostify | Hide Seen, Typing & Story Views",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "Control your visibility on Instagram & Facebook/Messenger. Hide typing indicators, read receipts, and story views.",
     "author": "Hendrizzzz",
     "permissions": [

--- a/dist/popup.html
+++ b/dist/popup.html
@@ -86,7 +86,11 @@
 
         <footer class="footer">
             <span id="version-number"></span>
-            <a class="support-link" href="https://github.com/Hendrizzzz/Ghostify/issues/new?template=help_feedback.yml" target="_blank" rel="noopener noreferrer" aria-label="Get help or share feedback using a guided GitHub form" data-tooltip="Helpful bug reports or ideas will be credited in release notes and on the website, with permission.">Help &amp; feedback</a>
+            <nav class="footer-links" aria-label="Ghostify links">
+                <a class="footer-link survey-link" href="https://docs.google.com/forms/d/e/1FAIpQLSddFGgzML2BCOJKTgVBaopmmzl0p1gBMkLEFMS5ofQY7hg89w/viewform" target="_blank" rel="noopener noreferrer" aria-label="Open the Ghostify View Once feature survey" data-tooltip="Share whether View Once media support fits Ghostify.">Feature survey</a>
+                <span class="footer-separator" aria-hidden="true">/</span>
+                <a class="footer-link support-link" href="https://github.com/Hendrizzzz/Ghostify/issues/new?template=help_feedback.yml" target="_blank" rel="noopener noreferrer" aria-label="Get help or share feedback using a guided GitHub form" data-tooltip="Helpful bug reports or ideas will be credited in release notes and on the website, with permission.">Help &amp; feedback</a>
+            </nav>
         </footer>
     </main>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghostify",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghostify",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.27.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghostify",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Privacy controls for Instagram, Facebook, and Messenger.",
   "main": "index.js",
   "scripts": {

--- a/test/messenger-send-stability.test.js
+++ b/test/messenger-send-stability.test.js
@@ -3993,7 +3993,9 @@ function testPopupSupportLinksUseGuidedIssueForms() {
     const popupHtml = fs.readFileSync('dist/popup.html', 'utf8');
     const popupCss = fs.readFileSync('dist/css/popup.css', 'utf8');
     const websiteUrl = 'https://ghostify-extension.vercel.app/';
+    const surveyUrl = 'https://docs.google.com/forms/d/e/1FAIpQLSddFGgzML2BCOJKTgVBaopmmzl0p1gBMkLEFMS5ofQY7hg89w/viewform';
     const directHelpFormUrl = 'https://github.com/Hendrizzzz/Ghostify/issues/new?template=help_feedback.yml';
+    const surveyTooltip = 'Share whether View Once media support fits Ghostify.';
     const thanksTooltip = 'Helpful bug reports or ideas will be credited in release notes and on the website, with permission.';
     const directHelpPlaceholder = 'Example: On facebook.com, I clicked New message requests and it opened a blank chat page instead of the request list. I expected Ghostify to keep the real UI working while Seen stays blocked.';
     const issueTemplateFiles = [
@@ -4023,6 +4025,19 @@ function testPopupSupportLinksUseGuidedIssueForms() {
         !popupHtml.includes('issues/new/choose') &&
         !popupHtml.includes('Report issue'),
         'Popup should open one guided Help & feedback draft directly instead of the issue chooser'
+    );
+    assert(
+        popupHtml.includes(`href="${surveyUrl}"`) &&
+        popupHtml.includes('Feature survey') &&
+        popupHtml.includes(`data-tooltip="${surveyTooltip}"`),
+        'Popup should include the View Once feature survey as a quiet footer link'
+    );
+    assert(
+        popupHtml.includes('class="footer-link survey-link"') &&
+        popupCss.includes('.survey-link::after') &&
+        popupCss.includes('left: -88px;') &&
+        popupCss.includes('width: 220px;'),
+        'Popup survey tooltip should be shifted inside the narrow extension popup instead of clipping offscreen'
     );
     assert(
         popupCss.includes('.support-link::after') &&


### PR DESCRIPTION
Adds a small popup link to a user survey about whether View Once media support fits Ghostify.

This does not implement the feature yet. It is only to collect feedback before deciding, since the request is useful but touches Ghostify’s privacy positioning.

Related to #32