### PR TITLE
chore: strengthen CI automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Manila
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - bot
+      - area:ci
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:15"
+      timezone: Asia/Manila
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - bot
+      - area:extension
+    groups:
+      extension-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /site
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:30"
+      timezone: Asia/Manila
+    open-pull-requests-limit: 3
+    labels:
+      - dependencies
+      - bot
+      - area:site
+    groups:
+      site-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,14 +20,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  extension:
-    name: Extension checks (Node ${{ matrix.node-version }})
-    runs-on: ubuntu-latest
+  workflow-lint:
+    name: Workflow lint
+    runs-on: ubuntu-24.04
 
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: ["24.x"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        run: docker run --rm -v "${{ github.workspace }}:/repo" --workdir /repo rhysd/actionlint:1.7.12 -color
+
+  extension:
+    name: Extension checks
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Check out repository
@@ -38,107 +46,41 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 24.x
           cache: npm
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Build and test extension
-        run: npm test
+      - name: Run extension CI
+        run: npm run ci
 
-      - name: Validate extension package
-        run: |
-          node <<'NODE'
-          const fs = require('fs');
-          const path = require('path');
-          const vm = require('vm');
+  site:
+    name: Site build
+    runs-on: ubuntu-24.04
 
-          function readJson(file) {
-            return JSON.parse(fs.readFileSync(file, 'utf8'));
-          }
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
-          function fail(message) {
-            throw new Error(message);
-          }
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: npm
+          cache-dependency-path: site/package-lock.json
 
-          function stableJson(value) {
-            if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
-            if (value && typeof value === 'object') {
-              return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(',')}}`;
-            }
-            return JSON.stringify(value);
-          }
+      - name: Install site dependencies
+        run: npm ci
+        working-directory: site
 
-          function readFallbackConfig(source) {
-            const match = source.match(/const FALLBACK_CONFIG\s*=\s*({[\s\S]*?});\s*const DEFAULT_SETTINGS/);
-            if (!match) fail('src/content.js must declare FALLBACK_CONFIG before DEFAULT_SETTINGS');
-            return vm.runInNewContext(`(${match[1]})`, Object.create(null));
-          }
+      - name: Build site
+        run: npm run build
+        working-directory: site
 
-          const pkg = readJson('package.json');
-          const lock = readJson('package-lock.json');
-          const manifest = readJson('dist/manifest.json');
-          const patterns = readJson('dist/config/patterns.json');
-          const contentSource = fs.readFileSync('src/content.js', 'utf8');
-          const fallbackConfig = readFallbackConfig(contentSource);
-          const fallbackVersion = fallbackConfig.version;
-
-          if (!pkg.version) fail('package.json must declare a version');
-          if (lock.version && lock.version !== pkg.version) {
-            fail(`package-lock.json version ${lock.version} does not match package.json ${pkg.version}`);
-          }
-          if (lock.packages?.['']?.version && lock.packages[''].version !== pkg.version) {
-            fail(`package-lock root package version ${lock.packages[''].version} does not match package.json ${pkg.version}`);
-          }
-          if (manifest.manifest_version !== 3) fail('dist/manifest.json manifest_version must be 3');
-          if (manifest.version !== pkg.version) {
-            fail(`dist/manifest.json version ${manifest.version} does not match package.json ${pkg.version}`);
-          }
-          if (patterns.version !== pkg.version) {
-            fail(`dist/config/patterns.json version ${patterns.version} does not match package.json ${pkg.version}`);
-          }
-          if (fallbackVersion !== pkg.version) {
-            fail(`src/content.js fallback config version ${fallbackVersion || '<missing>'} does not match package.json ${pkg.version}`);
-          }
-          if (stableJson(fallbackConfig.killSwitch || []) !== stableJson(patterns.killSwitch || [])) {
-            fail('src/content.js fallback killSwitch does not match dist/config/patterns.json');
-          }
-          if (stableJson(fallbackConfig.patterns || {}) !== stableJson(patterns.patterns || {})) {
-            fail('src/content.js fallback patterns do not match dist/config/patterns.json');
-          }
-
-          const requiredFiles = new Set();
-
-          function addRequired(file, label) {
-            if (!file || typeof file !== 'string') fail(`${label} must be a non-empty string`);
-            requiredFiles.add(file.replace(/^\/+/, ''));
-          }
-
-          addRequired(manifest.background?.service_worker, 'background.service_worker');
-          addRequired(manifest.action?.default_popup, 'action.default_popup');
-          Object.entries(manifest.icons || {}).forEach(([size, file]) => addRequired(file, `icons.${size}`));
-
-          for (const [index, script] of (manifest.content_scripts || []).entries()) {
-            if (!Array.isArray(script.js) || script.js.length === 0) {
-              fail(`content_scripts[${index}].js must list at least one script`);
-            }
-            script.js.forEach(file => addRequired(file, `content_scripts[${index}].js`));
-          }
-
-          for (const [index, group] of (manifest.web_accessible_resources || []).entries()) {
-            if (!Array.isArray(group.resources) || group.resources.length === 0) {
-              fail(`web_accessible_resources[${index}].resources must list at least one resource`);
-            }
-            group.resources.forEach(file => addRequired(file, `web_accessible_resources[${index}].resources`));
-          }
-
-          for (const file of requiredFiles) {
-            const fullPath = path.join('dist', file);
-            if (!fs.existsSync(fullPath)) fail(`Missing manifest asset: ${fullPath}`);
-          }
-          NODE
-
-      - name: Verify generated dist is committed
-        run: git diff --exit-code -- dist/background.js dist/js/content.js dist/js/ghost.js dist/js/messenger_patch.js
+      - name: Audit site dependencies
+        run: npm audit --audit-level=high
+        working-directory: site

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ grouped by version, with the most recent changes first.
 - Added GitHub Actions CI for the root extension package. The workflow installs
   dependencies with `npm ci`, runs `npm test`, validates extension package
   metadata, and verifies generated `dist/` bundles are committed.
+- Added workflow linting, site build checks, high-severity npm audit gates, and
+  Dependabot version-update automation for GitHub Actions, extension
+  dependencies, and website dependencies.
 - Added `RELEASE_CHECKLIST.md` to make version synchronization, automated tests,
   manual Meta-platform smoke tests, Chrome Web Store packaging, privacy review,
   and post-release steps explicit.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -117,11 +117,12 @@ Install from the lockfile and run the full extension test command:
 
 ```bash
 npm ci
-npm test
+npm run ci
 ```
 
-`npm test` runs `npm run build` first. After it finishes, confirm generated
-extension files are committed:
+`npm run ci` runs the extension build/test harness, package validation,
+generated-dist check, and high-severity dependency audit. After it finishes,
+confirm generated extension files are committed:
 
 ```bash
 git diff --exit-code -- dist/background.js dist/js/content.js dist/js/ghost.js dist/js/messenger_patch.js

--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "main": "index.js",
   "scripts": {
     "build": "node build.js",
-    "test": "npm run build && node test/messenger-send-stability.test.js"
+    "test": "npm run build && node test/messenger-send-stability.test.js",
+    "validate:extension": "node scripts/validate-extension-package.js",
+    "verify:dist": "git diff --exit-code -- dist/background.js dist/js/content.js dist/js/ghost.js dist/js/messenger_patch.js",
+    "audit:high": "npm audit --audit-level=high",
+    "ci": "npm test && npm run validate:extension && npm run verify:dist && npm run audit:high"
   },
   "repository": {
     "type": "git",

--- a/scripts/validate-extension-package.js
+++ b/scripts/validate-extension-package.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function readJson(file) {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+function fail(message) {
+    throw new Error(message);
+}
+
+function stableJson(value) {
+    if (Array.isArray(value)) return `[${value.map(stableJson).join(',')}]`;
+    if (value && typeof value === 'object') {
+        return `{${Object.keys(value)
+            .sort()
+            .map(key => `${JSON.stringify(key)}:${stableJson(value[key])}`)
+            .join(',')}}`;
+    }
+    return JSON.stringify(value);
+}
+
+function readFallbackConfig(source) {
+    const match = source.match(/const FALLBACK_CONFIG\s*=\s*({[\s\S]*?});\s*const DEFAULT_SETTINGS/);
+    if (!match) fail('src/content.js must declare FALLBACK_CONFIG before DEFAULT_SETTINGS');
+    return vm.runInNewContext(`(${match[1]})`, Object.create(null));
+}
+
+const pkg = readJson('package.json');
+const lock = readJson('package-lock.json');
+const manifest = readJson('dist/manifest.json');
+const patterns = readJson('dist/config/patterns.json');
+const contentSource = fs.readFileSync('src/content.js', 'utf8');
+const fallbackConfig = readFallbackConfig(contentSource);
+
+if (!pkg.version) fail('package.json must declare a version');
+if (lock.version && lock.version !== pkg.version) {
+    fail(`package-lock.json version ${lock.version} does not match package.json ${pkg.version}`);
+}
+if (lock.packages?.['']?.version && lock.packages[''].version !== pkg.version) {
+    fail(`package-lock root package version ${lock.packages[''].version} does not match package.json ${pkg.version}`);
+}
+if (manifest.manifest_version !== 3) fail('dist/manifest.json manifest_version must be 3');
+if (manifest.version !== pkg.version) {
+    fail(`dist/manifest.json version ${manifest.version} does not match package.json ${pkg.version}`);
+}
+if (patterns.version !== pkg.version) {
+    fail(`dist/config/patterns.json version ${patterns.version} does not match package.json ${pkg.version}`);
+}
+if (fallbackConfig.version !== pkg.version) {
+    fail(`src/content.js fallback config version ${fallbackConfig.version || '<missing>'} does not match package.json ${pkg.version}`);
+}
+if (stableJson(fallbackConfig.killSwitch || []) !== stableJson(patterns.killSwitch || [])) {
+    fail('src/content.js fallback killSwitch does not match dist/config/patterns.json');
+}
+if (stableJson(fallbackConfig.patterns || {}) !== stableJson(patterns.patterns || {})) {
+    fail('src/content.js fallback patterns do not match dist/config/patterns.json');
+}
+
+const requiredFiles = new Set();
+
+function addRequired(file, label) {
+    if (!file || typeof file !== 'string') fail(`${label} must be a non-empty string`);
+    requiredFiles.add(file.replace(/^\/+/, ''));
+}
+
+addRequired(manifest.background?.service_worker, 'background.service_worker');
+addRequired(manifest.action?.default_popup, 'action.default_popup');
+Object.entries(manifest.icons || {}).forEach(([size, file]) => addRequired(file, `icons.${size}`));
+
+for (const [index, script] of (manifest.content_scripts || []).entries()) {
+    if (!Array.isArray(script.js) || script.js.length === 0) {
+        fail(`content_scripts[${index}].js must list at least one script`);
+    }
+    script.js.forEach(file => addRequired(file, `content_scripts[${index}].js`));
+}
+
+for (const [index, group] of (manifest.web_accessible_resources || []).entries()) {
+    if (!Array.isArray(group.resources) || group.resources.length === 0) {
+        fail(`web_accessible_resources[${index}].resources must list at least one resource`);
+    }
+    group.resources.forEach(file => addRequired(file, `web_accessible_resources[${index}].resources`));
+}
+
+for (const file of requiredFiles) {
+    const fullPath = path.join('dist', file);
+    if (!fs.existsSync(fullPath)) fail(`Missing manifest asset: ${fullPath}`);
+}
+
+console.log(`extension package metadata and fallback config are valid for ${pkg.version}`);


### PR DESCRIPTION
﻿## Summary
- Split CI into workflow lint, extension checks, and site build jobs with stable check names.
- Move extension package validation into a local script and expose reusable npm CI scripts.
- Add high-severity npm audit gates and Dependabot updates for GitHub Actions, root npm, and site npm dependencies.

## Test Plan
- `actionlint .github\workflows\ci.yml`
- `npm run ci`
- `npm run build` in `site/`
- `npm audit --audit-level=high` in `site/`
