### PR TITLE
Clarify privacy control scope

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,16 +1,16 @@
 # Privacy Policy for Ghostify
 
-**Last Updated:** June 20, 2026
+**Last Updated:** July 9, 2026
 
 ## 1. Introduction
 Ghostify ("we," "our," or "the Extension") is a browser extension designed to enhance user privacy on social media platforms by preventing the transmission of "read receipts," "typing indicators," and "story view" telemetry. We are committed to protecting your personal information and your right to privacy.
 
-Ghostify's extension runtime does not collect or transmit messages, credentials, social media content, browsing activity, tab URLs, or settings to Ghostify or to Ghostify-operated services. The popup may request Ghostify's public `status.json` feed to display verification summaries; that request is display-only and does not include extension settings, tab URLs, messages, or social media activity. We are not affiliated with Meta Platforms, Inc.
+For the privacy controls described in this policy, Ghostify's extension runtime does not collect or transmit messages, credentials, social media content, browsing activity, tab URLs, or settings to Ghostify or to Ghostify-operated services. The popup may request Ghostify's public `status.json` feed to display verification summaries; that request is display-only and does not include extension settings, tab URLs, messages, or social media activity. We are not affiliated with Meta Platforms, Inc.
 
 ## 2. Data Collection and Usage
 **Ghostify's extension runtime does not collect, store, share, or sell your personal data.**
 
-The Extension operates entirely locally on your device ("client-side"). Ghostify transiently inspects request URLs, request payloads, and supported page or worker messages inside your browser to identify privacy signals such as read receipts, typing indicators, and story-view writes. Ghostify does not send this inspected data to a Ghostify server and does not store raw messages, credentials, browsing history, or social media content.
+These privacy controls operate locally on your device ("client-side"). Ghostify transiently inspects request URLs, request payloads, and supported page or worker messages inside your browser to identify privacy signals such as read receipts, typing indicators, and story-view writes. Ghostify does not send this inspected data to a Ghostify server and does not store raw messages, credentials, browsing history, or social media content.
 
 The popup can fetch a public verification-status JSON file from Ghostify's website so it can show whether supported features are verified, under review, stale, or unavailable. This status feed is not personalized and is not used to collect your social media activity.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Privacy controls for Instagram, Facebook, and Messenger web.
 
 </div>
 
-Ghostify is a Manifest V3 browser extension that helps reduce social pressure on Meta web apps. It blocks supported read receipts, typing indicators, and story-view signals locally in the browser, without requiring a Ghostify account or asking for social media passwords.
+Ghostify is a Manifest V3 browser extension that helps reduce social pressure on Meta web apps. Its privacy controls block supported read receipts, typing indicators, and story-view signals locally in the browser, without requiring a Ghostify account or asking for social media passwords.
 
 ## Features
 
@@ -56,22 +56,22 @@ release notes when a matching GitHub release has been published.
 
 ## How It Works
 
-Ghostify runs locally through browser extension APIs:
+Ghostify's privacy controls run locally through browser extension APIs:
 
 - `declarativeNetRequest` rules block known privacy-related endpoints where static rules are reliable.
 - Content scripts and page-context patches handle modern Meta web app behavior that cannot be covered by static rules alone.
 - User settings are saved in extension storage and synced to open Instagram, Facebook, and Messenger tabs.
 
-Ghostify does not run a tracking server and does not collect, sell, or share user activity through the extension runtime. The popup may request Ghostify's public `status.json` feed to display verification summaries; that request does not include your messages, tab URLs, settings, or social media activity.
+Ghostify does not run a tracking server for extension activity and does not collect, sell, or share user activity through the extension runtime. The popup may request Ghostify's public `status.json` feed to display verification summaries; that request does not include your messages, tab URLs, settings, or social media activity.
 
 ## Privacy
 
-Ghostify is designed to work entirely inside your browser.
+Ghostify's privacy controls are designed to work inside your browser.
 
 It does not:
 
 - collect your messages through Ghostify's extension runtime
-- require a Ghostify account
+- require a Ghostify account for these privacy controls
 - ask for Instagram, Facebook, or Messenger passwords
 - send your browsing activity, messages, tab URLs, or settings to a Ghostify server
 

--- a/site/src/app/components/FAQSection.tsx
+++ b/site/src/app/components/FAQSection.tsx
@@ -25,7 +25,7 @@ const FAQS = [
   },
   {
     q: 'Does it store my activity?',
-    a: 'No. Ghostify has no tracking server, no analytics, and no Ghostify cloud sync. Toggle settings and bundled config stay in your browser, and setting changes are broadcast only to open supported tabs.',
+    a: 'No. Ghostify does not use a tracking server or analytics for extension activity. Toggle settings and bundled config stay in your browser, and setting changes are broadcast only to open supported tabs.',
   },
   {
     q: 'Is this ethical?',


### PR DESCRIPTION
## Summary
- Scope README privacy wording to Ghostify's privacy controls and extension activity.
- Update the privacy policy date and clarify local handling for described privacy controls.
- Clarify the website FAQ wording around tracking and analytics for extension activity.

## Validation
- npm run validate:extension
- npm run build (from site/)