### PR TITLE
chore: add free core module registry foundation

### DIFF
--- a/dist/background.js
+++ b/dist/background.js
@@ -1,11 +1,41 @@
 (() => {
-  // src/background.js
-  var DEFAULT_SETTINGS = {
-    igStory: true,
+  // src/settings/defaults.js
+  var FREE_PRIVACY_SETTING_KEYS = Object.freeze([
+    "igTyping",
+    "igSeen",
+    "igStory",
+    "msgTyping",
+    "msgSeen",
+    "msgStory"
+  ]);
+  var DEFAULT_PRIVACY_SETTINGS = Object.freeze({
     igTyping: true,
+    igSeen: true,
+    igStory: true,
     msgTyping: true,
-    msgSeen: true
-  };
+    msgSeen: true,
+    msgStory: true
+  });
+  var DEFAULT_MODULE_FLAGS = Object.freeze({
+    ghostMode: true
+  });
+
+  // src/settings/storage.js
+  var GHOSTIFY_SETTINGS_STORAGE_KEY = "ghostifySettings";
+  function normalizePrivacySettings(settings) {
+    const normalized = { ...DEFAULT_PRIVACY_SETTINGS };
+    if (!settings || typeof settings !== "object" || Array.isArray(settings)) {
+      return normalized;
+    }
+    for (const key of FREE_PRIVACY_SETTING_KEYS) {
+      if (typeof settings[key] === "boolean") {
+        normalized[key] = settings[key];
+      }
+    }
+    return normalized;
+  }
+
+  // src/background.js
   var DYNAMIC_RULE_IDS = {
     instagramStorySeen: 1001,
     instagramBanzai: 1002,
@@ -53,8 +83,8 @@
   chrome.runtime.onInstalled.addListener(syncDynamicPrivacyRulesFromStorage);
   chrome.runtime.onStartup.addListener(syncDynamicPrivacyRulesFromStorage);
   chrome.storage.onChanged.addListener((changes, areaName) => {
-    if (areaName !== "local" || !changes.ghostifySettings) return;
-    syncDynamicPrivacyRules(normalizeSettings(changes.ghostifySettings.newValue)).catch(() => {
+    if (areaName !== "local" || !changes[GHOSTIFY_SETTINGS_STORAGE_KEY]) return;
+    syncDynamicPrivacyRules(normalizePrivacySettings(changes[GHOSTIFY_SETTINGS_STORAGE_KEY].newValue)).catch(() => {
     });
   });
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -64,13 +94,10 @@
     return true;
   });
   function syncDynamicPrivacyRulesFromStorage() {
-    chrome.storage.local.get(["ghostifySettings"], (result) => {
-      syncDynamicPrivacyRules(normalizeSettings(result.ghostifySettings)).catch(() => {
+    chrome.storage.local.get([GHOSTIFY_SETTINGS_STORAGE_KEY], (result) => {
+      syncDynamicPrivacyRules(normalizePrivacySettings(result[GHOSTIFY_SETTINGS_STORAGE_KEY])).catch(() => {
       });
     });
-  }
-  function normalizeSettings(settings) {
-    return Object.assign({}, DEFAULT_SETTINGS, settings || {});
   }
   async function syncDynamicPrivacyRules(settings) {
     var _a;

--- a/dist/js/content.js
+++ b/dist/js/content.js
@@ -1,4 +1,43 @@
 (() => {
+  // src/settings/defaults.js
+  var FREE_PRIVACY_SETTING_KEYS = Object.freeze([
+    "igTyping",
+    "igSeen",
+    "igStory",
+    "msgTyping",
+    "msgSeen",
+    "msgStory"
+  ]);
+  var DEFAULT_PRIVACY_SETTINGS = Object.freeze({
+    igTyping: true,
+    igSeen: true,
+    igStory: true,
+    msgTyping: true,
+    msgSeen: true,
+    msgStory: true
+  });
+  var DEFAULT_MODULE_FLAGS = Object.freeze({
+    ghostMode: true
+  });
+
+  // src/settings/storage.js
+  var GHOSTIFY_SETTINGS_STORAGE_KEY = "ghostifySettings";
+  function normalizePrivacySettings(settings) {
+    const normalized = { ...DEFAULT_PRIVACY_SETTINGS };
+    if (!settings || typeof settings !== "object" || Array.isArray(settings)) {
+      return normalized;
+    }
+    for (const key of FREE_PRIVACY_SETTING_KEYS) {
+      if (typeof settings[key] === "boolean") {
+        normalized[key] = settings[key];
+      }
+    }
+    return normalized;
+  }
+  function sanitizePrivacySettingsForPage(settings) {
+    return normalizePrivacySettings(settings);
+  }
+
   // src/content.js
   var FALLBACK_CONFIG = {
     version: "2.0.4",
@@ -11,14 +50,6 @@
       msgSeen: ["mark_read", "mark_seen", "thread_seen", "DirectMarkAsSeen", "MarkAsSeen", "DirectThreadMarkItemsSeen", "PolarisDirectMarkAsSeenMutation", "DirectSeenMutation", "seenByViewer", "updateLastSeenAt", "updateLastReadWatermark", "sendReadReceipt", "LSSendReadReceipt", "readReceipt", "read_receipt", "readReceiptMutation", "LSUpdateThreadReadWatermark", "LSUpdateLastReadWatermark", "last_read_watermark", "lastReadWatermark", "read_watermark", "readWatermark", "shouldSendReadReceipt", "should_send_read_receipt", "LSMarkThreadRead", "MWMarkThreadRead", "markAsRead", "change_read_status"],
       msgStory: ["StoriesUpdateSeenMutation", "PolarisStoriesSeenMutation", "usePolarisStoriesV3SeenMutation", "reelMediaSeen", "storiesUpdateSeen", "SeenStoriesUpdateMutation", "mark_story_seen", "update_seen_for_reel", "reel_seen", "viewer_seen", "stories_update_seen", "mark_story_read"]
     }
-  };
-  var DEFAULT_SETTINGS = {
-    igTyping: true,
-    igSeen: true,
-    igStory: true,
-    msgTyping: true,
-    msgSeen: true,
-    msgStory: true
   };
   (async function init() {
     syncUserSettings();
@@ -65,8 +96,8 @@
       }, "*");
     }
     function loadAndSend() {
-      chrome.storage.local.get(["ghostifySettings"], (result) => {
-        const settings = result.ghostifySettings || DEFAULT_SETTINGS;
+      chrome.storage.local.get([GHOSTIFY_SETTINGS_STORAGE_KEY], (result) => {
+        const settings = sanitizePrivacySettingsForPage(result[GHOSTIFY_SETTINGS_STORAGE_KEY]);
         sendSettingsToPage(settings);
       });
     }
@@ -81,8 +112,8 @@
     setTimeout(loadAndSend, 500);
     setTimeout(loadAndSend, 1500);
     chrome.storage.onChanged.addListener((changes, areaName) => {
-      if (areaName === "local" && changes.ghostifySettings) {
-        const newSettings = changes.ghostifySettings.newValue;
+      if (areaName === "local" && changes[GHOSTIFY_SETTINGS_STORAGE_KEY]) {
+        const newSettings = sanitizePrivacySettingsForPage(changes[GHOSTIFY_SETTINGS_STORAGE_KEY].newValue);
         sendSettingsToPage(newSettings);
       }
     });

--- a/dist/js/ghost.js
+++ b/dist/js/ghost.js
@@ -1,13 +1,27 @@
 (() => {
-  // src/config.js
-  var SETTINGS = {
+  // src/settings/defaults.js
+  var FREE_PRIVACY_SETTING_KEYS = Object.freeze([
+    "igTyping",
+    "igSeen",
+    "igStory",
+    "msgTyping",
+    "msgSeen",
+    "msgStory"
+  ]);
+  var DEFAULT_PRIVACY_SETTINGS = Object.freeze({
     igTyping: true,
     igSeen: true,
     igStory: true,
     msgTyping: true,
     msgSeen: true,
     msgStory: true
-  };
+  });
+  var DEFAULT_MODULE_FLAGS = Object.freeze({
+    ghostMode: true
+  });
+
+  // src/config.js
+  var SETTINGS = { ...DEFAULT_PRIVACY_SETTINGS };
   var KILLED_FEATURES = /* @__PURE__ */ new Set();
   var SETTINGS_READY = false;
   var hostname = window.location.hostname.toLowerCase();

--- a/dist/js/messenger_patch.js
+++ b/dist/js/messenger_patch.js
@@ -1,4 +1,25 @@
 (() => {
+  // src/settings/defaults.js
+  var FREE_PRIVACY_SETTING_KEYS = Object.freeze([
+    "igTyping",
+    "igSeen",
+    "igStory",
+    "msgTyping",
+    "msgSeen",
+    "msgStory"
+  ]);
+  var DEFAULT_PRIVACY_SETTINGS = Object.freeze({
+    igTyping: true,
+    igSeen: true,
+    igStory: true,
+    msgTyping: true,
+    msgSeen: true,
+    msgStory: true
+  });
+  var DEFAULT_MODULE_FLAGS = Object.freeze({
+    ghostMode: true
+  });
+
   // src/messenger_patch.js
   (function() {
     "use strict";
@@ -29,11 +50,7 @@
     function isHost(host, domain) {
       return host === domain || host.endsWith(`.${domain}`);
     }
-    const DEFAULT_SETTINGS = {
-      igTyping: true,
-      msgTyping: true,
-      msgSeen: true
-    };
+    const DEFAULT_SETTINGS = DEFAULT_PRIVACY_SETTINGS;
     const OBSERVE_TERMS = [
       "sendtypingindicator",
       "lssendtypingindicator",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "build": "node build.js",
-    "test": "npm run build && node test/messenger-send-stability.test.js && npm run test:validator && npm run test:package",
+    "test": "npm run build && npm run test:modules && node test/messenger-send-stability.test.js && npm run test:validator && npm run test:package",
+    "test:modules": "node test/settings-defaults.test.js && node test/module-registry.test.js && node test/module-flags.test.js",
     "test:validator": "node test/validate-extension-package.test.js",
     "test:package": "node test/package-extension.test.js",
     "package:extension": "node scripts/package-extension.js",

--- a/scripts/validate-extension-package.js
+++ b/scripts/validate-extension-package.js
@@ -27,10 +27,51 @@ function stableJson(value) {
     return JSON.stringify(value);
 }
 
+function readConstObjectLiteral(source, constName) {
+    const declaration = `const ${constName}`;
+    const declarationIndex = source.indexOf(declaration);
+    if (declarationIndex < 0) fail(`src/content.js must declare ${constName}`);
+
+    const braceStart = source.indexOf('{', declarationIndex);
+    if (braceStart < 0) fail(`src/content.js ${constName} must be an object literal`);
+
+    let depth = 0;
+    let quote = null;
+    let escaped = false;
+
+    for (let index = braceStart; index < source.length; index += 1) {
+        const char = source[index];
+
+        if (quote) {
+            if (escaped) {
+                escaped = false;
+            } else if (char === '\\') {
+                escaped = true;
+            } else if (char === quote) {
+                quote = null;
+            }
+            continue;
+        }
+
+        if (char === '"' || char === "'" || char === '`') {
+            quote = char;
+            continue;
+        }
+
+        if (char === '{') depth += 1;
+        if (char === '}') {
+            depth -= 1;
+            if (depth === 0) {
+                return source.slice(braceStart, index + 1);
+            }
+        }
+    }
+
+    fail(`src/content.js ${constName} object literal is incomplete`);
+}
+
 function readFallbackConfig(source) {
-    const match = source.match(/const FALLBACK_CONFIG\s*=\s*({[\s\S]*?});\s*const DEFAULT_SETTINGS/);
-    if (!match) fail('src/content.js must declare FALLBACK_CONFIG before DEFAULT_SETTINGS');
-    return vm.runInNewContext(`(${match[1]})`, Object.create(null));
+    return vm.runInNewContext(`(${readConstObjectLiteral(source, 'FALLBACK_CONFIG')})`, Object.create(null));
 }
 
 const pkg = readJson(repoPath('package.json'));

--- a/src/background.js
+++ b/src/background.js
@@ -1,9 +1,4 @@
-const DEFAULT_SETTINGS = {
-    igStory: true,
-    igTyping: true,
-    msgTyping: true,
-    msgSeen: true
-};
+import { GHOSTIFY_SETTINGS_STORAGE_KEY, normalizePrivacySettings } from './settings/storage.js';
 
 const DYNAMIC_RULE_IDS = {
     instagramStorySeen: 1001,
@@ -58,8 +53,8 @@ chrome.runtime.onInstalled.addListener(syncDynamicPrivacyRulesFromStorage);
 chrome.runtime.onStartup.addListener(syncDynamicPrivacyRulesFromStorage);
 
 chrome.storage.onChanged.addListener((changes, areaName) => {
-    if (areaName !== 'local' || !changes.ghostifySettings) return;
-    syncDynamicPrivacyRules(normalizeSettings(changes.ghostifySettings.newValue)).catch(() => { });
+    if (areaName !== 'local' || !changes[GHOSTIFY_SETTINGS_STORAGE_KEY]) return;
+    syncDynamicPrivacyRules(normalizePrivacySettings(changes[GHOSTIFY_SETTINGS_STORAGE_KEY].newValue)).catch(() => { });
 });
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -70,13 +65,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 function syncDynamicPrivacyRulesFromStorage() {
-    chrome.storage.local.get(['ghostifySettings'], (result) => {
-        syncDynamicPrivacyRules(normalizeSettings(result.ghostifySettings)).catch(() => { });
+    chrome.storage.local.get([GHOSTIFY_SETTINGS_STORAGE_KEY], (result) => {
+        syncDynamicPrivacyRules(normalizePrivacySettings(result[GHOSTIFY_SETTINGS_STORAGE_KEY])).catch(() => { });
     });
-}
-
-function normalizeSettings(settings) {
-    return Object.assign({}, DEFAULT_SETTINGS, settings || {});
 }
 
 async function syncDynamicPrivacyRules(settings) {

--- a/src/config.js
+++ b/src/config.js
@@ -1,11 +1,6 @@
-export const SETTINGS = {
-    igTyping: true,
-    igSeen: true,
-    igStory: true,
-    msgTyping: true,
-    msgSeen: true,
-    msgStory: true
-};
+import { DEFAULT_PRIVACY_SETTINGS } from './settings/defaults.js';
+
+export const SETTINGS = { ...DEFAULT_PRIVACY_SETTINGS };
 
 export const KILLED_FEATURES = new Set();
 export let SETTINGS_READY = false;

--- a/src/content.js
+++ b/src/content.js
@@ -1,3 +1,5 @@
+import { GHOSTIFY_SETTINGS_STORAGE_KEY, sanitizePrivacySettingsForPage } from './settings/storage.js';
+
 const FALLBACK_CONFIG = {
     version: "2.0.4",
     killSwitch: [],
@@ -9,15 +11,6 @@ const FALLBACK_CONFIG = {
         msgSeen: ['mark_read', 'mark_seen', 'thread_seen', 'DirectMarkAsSeen', 'MarkAsSeen', 'DirectThreadMarkItemsSeen', 'PolarisDirectMarkAsSeenMutation', 'DirectSeenMutation', 'seenByViewer', 'updateLastSeenAt', 'updateLastReadWatermark', 'sendReadReceipt', 'LSSendReadReceipt', 'readReceipt', 'read_receipt', 'readReceiptMutation', 'LSUpdateThreadReadWatermark', 'LSUpdateLastReadWatermark', 'last_read_watermark', 'lastReadWatermark', 'read_watermark', 'readWatermark', 'shouldSendReadReceipt', 'should_send_read_receipt', 'LSMarkThreadRead', 'MWMarkThreadRead', 'markAsRead', 'change_read_status'],
         msgStory: ['StoriesUpdateSeenMutation', 'PolarisStoriesSeenMutation', 'usePolarisStoriesV3SeenMutation', 'reelMediaSeen', 'storiesUpdateSeen', 'SeenStoriesUpdateMutation', 'mark_story_seen', 'update_seen_for_reel', 'reel_seen', 'viewer_seen', 'stories_update_seen', 'mark_story_read']
     }
-};
-
-const DEFAULT_SETTINGS = {
-    igTyping: true,
-    igSeen: true,
-    igStory: true,
-    msgTyping: true,
-    msgSeen: true,
-    msgStory: true
 };
 
 (async function init() {
@@ -70,8 +63,8 @@ function syncUserSettings() {
     }
 
     function loadAndSend() {
-        chrome.storage.local.get(['ghostifySettings'], (result) => {
-            const settings = result.ghostifySettings || DEFAULT_SETTINGS;
+        chrome.storage.local.get([GHOSTIFY_SETTINGS_STORAGE_KEY], (result) => {
+            const settings = sanitizePrivacySettingsForPage(result[GHOSTIFY_SETTINGS_STORAGE_KEY]);
             sendSettingsToPage(settings);
         });
     }
@@ -90,8 +83,8 @@ function syncUserSettings() {
     setTimeout(loadAndSend, 1500);
 
     chrome.storage.onChanged.addListener((changes, areaName) => {
-        if (areaName === 'local' && changes.ghostifySettings) {
-            const newSettings = changes.ghostifySettings.newValue;
+        if (areaName === 'local' && changes[GHOSTIFY_SETTINGS_STORAGE_KEY]) {
+            const newSettings = sanitizePrivacySettingsForPage(changes[GHOSTIFY_SETTINGS_STORAGE_KEY].newValue);
             sendSettingsToPage(newSettings);
         }
     });

--- a/src/messenger_patch.js
+++ b/src/messenger_patch.js
@@ -1,3 +1,5 @@
+import { DEFAULT_PRIVACY_SETTINGS } from './settings/defaults.js';
+
 (function () {
     'use strict';
     const hostname = window.location.hostname.toLowerCase();
@@ -31,11 +33,7 @@
         return host === domain || host.endsWith(`.${domain}`);
     }
 
-    const DEFAULT_SETTINGS = {
-        igTyping: true,
-        msgTyping: true,
-        msgSeen: true
-    };
+    const DEFAULT_SETTINGS = DEFAULT_PRIVACY_SETTINGS;
     const OBSERVE_TERMS = [
         'sendtypingindicator',
         'lssendtypingindicator',

--- a/src/modules/registry.js
+++ b/src/modules/registry.js
@@ -1,0 +1,171 @@
+import {
+    DEFAULT_MODULE_FLAGS,
+    DEFAULT_PRIVACY_SETTINGS,
+    FREE_PRIVACY_SETTING_KEYS
+} from '../settings/defaults.js';
+
+export const PUBLIC_MODULE_REGISTRY_VERSION = 1;
+
+export const GHOSTIFY_MODULES = Object.freeze([
+    Object.freeze({
+        id: 'ghostMode',
+        label: 'Ghost Mode',
+        plan: 'free',
+        platforms: Object.freeze(['instagram', 'messenger', 'facebook']),
+        firstReleasePlatforms: Object.freeze(['instagram', 'messenger', 'facebook']),
+        plannedPlatforms: Object.freeze([]),
+        storageKey: 'ghostifySettings',
+        settingsKeys: FREE_PRIVACY_SETTING_KEYS,
+        defaultSettings: DEFAULT_PRIVACY_SETTINGS,
+        risk: 'core-privacy',
+        releaseStage: 'stable',
+        defaultEnabled: DEFAULT_MODULE_FLAGS.ghostMode,
+        entitlementFeature: null,
+        localKillSwitchKey: 'ghostMode',
+        remoteFlagKey: null,
+        manifestPermissionsWhenEnabled: Object.freeze(['storage', 'declarativeNetRequest']),
+        permissionCandidatesAfterReview: Object.freeze([]),
+        dataClass: 'local-settings-and-transient-page-traffic',
+        uiSurface: 'popup',
+        requiresAccount: false,
+        requiresRemoteService: false
+    })
+]);
+
+export const GHOSTIFY_MODULE_IDS = Object.freeze(GHOSTIFY_MODULES.map(module => module.id));
+
+const ALLOWED_REMOTE_POLICY_KEYS = Object.freeze([
+    'schemaVersion',
+    'disabledModules',
+    'limitOverrides',
+    'copy'
+]);
+
+const FORBIDDEN_REMOTE_POLICY_KEYS = new Set([
+    'selector',
+    'selectors',
+    'regex',
+    'regexes',
+    'matcher',
+    'matchers',
+    'action',
+    'actions',
+    'actionRule',
+    'actionRules',
+    'action_rules',
+    'css',
+    'script',
+    'scripts',
+    'template',
+    'templates',
+    'html',
+    'markdown',
+    'url',
+    'urls',
+    'enabledModules',
+    'enableModules',
+    'features',
+    'featureFlags',
+    'permissions',
+    'hostPermissions'
+]);
+
+const EXECUTABLE_TEXT_PATTERN = /<[^>]+>|javascript:|data:text\/html|eval\s*\(|function\s*\(|=>|import\s*\(|new\s+Function/i;
+const REMOTE_POLICY_MODULE_IDS = new Set(GHOSTIFY_MODULE_IDS);
+
+export function getGhostifyModule(id) {
+    return GHOSTIFY_MODULES.find(module => module.id === id) || null;
+}
+
+export function validateFreeCoreRemotePolicy(policy) {
+    const errors = [];
+    if (!isPlainObject(policy)) {
+        return ['remote policy must be an object'];
+    }
+
+    collectForbiddenRemotePolicyFields(policy, '', errors);
+
+    for (const key of Object.keys(policy)) {
+        if (!ALLOWED_REMOTE_POLICY_KEYS.includes(key)) {
+            errors.push(`remote policy field is not allowed: ${key}`);
+        }
+    }
+
+    if (policy.schemaVersion !== 1) {
+        errors.push('remote policy schemaVersion must be 1');
+    }
+
+    if (policy.disabledModules !== undefined) {
+        if (!Array.isArray(policy.disabledModules)) {
+            errors.push('remote policy disabledModules must be an array');
+        } else {
+            for (const moduleId of policy.disabledModules) {
+                if (typeof moduleId !== 'string' || !REMOTE_POLICY_MODULE_IDS.has(moduleId)) {
+                    errors.push(`remote policy disabledModules contains unknown module: ${String(moduleId)}`);
+                }
+            }
+        }
+    }
+
+    if (policy.limitOverrides !== undefined) {
+        if (!isPlainObject(policy.limitOverrides)) {
+            errors.push('remote policy limitOverrides must be an object');
+        } else {
+            for (const [key, value] of Object.entries(policy.limitOverrides)) {
+                if (!/^[a-z][A-Za-z0-9]*$/.test(key)) {
+                    errors.push(`remote policy limitOverrides key is invalid: ${key}`);
+                }
+                if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+                    errors.push(`remote policy limitOverrides.${key} must be a non-negative number`);
+                }
+            }
+        }
+    }
+
+    if (policy.copy !== undefined) {
+        if (!isPlainObject(policy.copy)) {
+            errors.push('remote policy copy must be an object');
+        } else {
+            for (const [key, value] of Object.entries(policy.copy)) {
+                if (!/^[a-z][A-Za-z0-9]*$/.test(key)) {
+                    errors.push(`remote policy copy key is invalid: ${key}`);
+                }
+                if (typeof value !== 'string') {
+                    errors.push(`remote policy copy.${key} must be a string`);
+                } else if (EXECUTABLE_TEXT_PATTERN.test(value)) {
+                    errors.push(`remote policy copy.${key} must be plain text`);
+                }
+            }
+        }
+    }
+
+    return errors;
+}
+
+export function assertFreeCoreRemotePolicy(policy) {
+    const errors = validateFreeCoreRemotePolicy(policy);
+    if (errors.length) {
+        throw new Error(errors.join('; '));
+    }
+    return true;
+}
+
+function collectForbiddenRemotePolicyFields(value, path, errors) {
+    if (!value || typeof value !== 'object') return;
+    if (Array.isArray(value)) {
+        value.forEach((item, index) => collectForbiddenRemotePolicyFields(item, `${path}[${index}]`, errors));
+        return;
+    }
+
+    for (const [key, child] of Object.entries(value)) {
+        const childPath = path ? `${path}.${key}` : key;
+        if (FORBIDDEN_REMOTE_POLICY_KEYS.has(key)) {
+            errors.push(`remote policy field is not allowed: ${childPath}`);
+        }
+        collectForbiddenRemotePolicyFields(child, childPath, errors);
+    }
+}
+
+function isPlainObject(value) {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/settings/defaults.js
+++ b/src/settings/defaults.js
@@ -1,0 +1,21 @@
+export const FREE_PRIVACY_SETTING_KEYS = Object.freeze([
+    'igTyping',
+    'igSeen',
+    'igStory',
+    'msgTyping',
+    'msgSeen',
+    'msgStory'
+]);
+
+export const DEFAULT_PRIVACY_SETTINGS = Object.freeze({
+    igTyping: true,
+    igSeen: true,
+    igStory: true,
+    msgTyping: true,
+    msgSeen: true,
+    msgStory: true
+});
+
+export const DEFAULT_MODULE_FLAGS = Object.freeze({
+    ghostMode: true
+});

--- a/src/settings/storage.js
+++ b/src/settings/storage.js
@@ -1,0 +1,22 @@
+import { DEFAULT_PRIVACY_SETTINGS, FREE_PRIVACY_SETTING_KEYS } from './defaults.js';
+
+export const GHOSTIFY_SETTINGS_STORAGE_KEY = 'ghostifySettings';
+
+export function normalizePrivacySettings(settings) {
+    const normalized = { ...DEFAULT_PRIVACY_SETTINGS };
+    if (!settings || typeof settings !== 'object' || Array.isArray(settings)) {
+        return normalized;
+    }
+
+    for (const key of FREE_PRIVACY_SETTING_KEYS) {
+        if (typeof settings[key] === 'boolean') {
+            normalized[key] = settings[key];
+        }
+    }
+
+    return normalized;
+}
+
+export function sanitizePrivacySettingsForPage(settings) {
+    return normalizePrivacySettings(settings);
+}

--- a/test/helpers/load-src-module.js
+++ b/test/helpers/load-src-module.js
@@ -1,0 +1,22 @@
+const Module = require('module');
+const path = require('path');
+const esbuild = require('esbuild');
+
+function loadSrcModule(relativePath) {
+    const absolutePath = path.resolve(__dirname, '..', '..', relativePath);
+    const result = esbuild.buildSync({
+        entryPoints: [absolutePath],
+        bundle: true,
+        platform: 'node',
+        format: 'cjs',
+        write: false,
+        logLevel: 'silent'
+    });
+    const compiled = new Module(absolutePath, module.parent);
+    compiled.filename = absolutePath;
+    compiled.paths = Module._nodeModulePaths(path.dirname(absolutePath));
+    compiled._compile(result.outputFiles[0].text, absolutePath);
+    return compiled.exports;
+}
+
+module.exports = { loadSrcModule };

--- a/test/module-flags.test.js
+++ b/test/module-flags.test.js
@@ -1,0 +1,87 @@
+const assert = require('assert');
+const { loadSrcModule } = require('./helpers/load-src-module');
+
+const {
+    assertFreeCoreRemotePolicy,
+    validateFreeCoreRemotePolicy
+} = loadSrcModule('src/modules/registry.js');
+
+assert.strictEqual(
+    assertFreeCoreRemotePolicy({
+        schemaVersion: 1,
+        disabledModules: ['ghostMode'],
+        limitOverrides: { diagnosticEventLimit: 100 },
+        copy: { status: 'Privacy controls are temporarily unavailable.' }
+    }),
+    true
+);
+
+function assertPolicyRejected(policy, pattern) {
+    const errors = validateFreeCoreRemotePolicy(policy);
+    assert(errors.length, 'remote policy should be rejected');
+    assert.match(errors.join('; '), pattern);
+    assert.throws(() => assertFreeCoreRemotePolicy(policy), pattern);
+}
+
+assertPolicyRejected(
+    {
+        schemaVersion: 1,
+        enabledModules: ['ghostMode']
+    },
+    /enabledModules/
+);
+
+assertPolicyRejected(
+    {
+        schemaVersion: 1,
+        disabledModules: ['futureModule']
+    },
+    /unknown module/
+);
+
+for (const blockedField of ['selectors', 'matchers', 'actionRules', 'scripts', 'templates']) {
+    assertPolicyRejected(
+        {
+            schemaVersion: 1,
+            [blockedField]: ['body']
+        },
+        new RegExp(blockedField)
+    );
+}
+
+assertPolicyRejected(
+    {
+        schemaVersion: 1,
+        disabledModules: ['ghostMode'],
+        copy: { status: '<script>alert(1)</script>' }
+    },
+    /plain text/
+);
+
+assertPolicyRejected(
+    {
+        schemaVersion: 1,
+        disabledModules: ['ghostMode'],
+        copy: { status: 'javascript:alert(1)' }
+    },
+    /plain text/
+);
+
+assertPolicyRejected(
+    {
+        schemaVersion: 1,
+        disabledModules: ['ghostMode'],
+        copy: { status: { text: 'Nested copy is not a plain string.' } }
+    },
+    /must be a string/
+);
+
+assertPolicyRejected(
+    {
+        schemaVersion: 2,
+        disabledModules: ['ghostMode']
+    },
+    /schemaVersion/
+);
+
+console.log('module remote-flag boundary tests passed');

--- a/test/module-registry.test.js
+++ b/test/module-registry.test.js
@@ -1,0 +1,89 @@
+const assert = require('assert');
+const fs = require('fs');
+const { loadSrcModule } = require('./helpers/load-src-module');
+
+const { DEFAULT_PRIVACY_SETTINGS, FREE_PRIVACY_SETTING_KEYS } = loadSrcModule('src/settings/defaults.js');
+const {
+    GHOSTIFY_MODULE_IDS,
+    GHOSTIFY_MODULES,
+    PUBLIC_MODULE_REGISTRY_VERSION,
+    getGhostifyModule
+} = loadSrcModule('src/modules/registry.js');
+
+const manifest = JSON.parse(fs.readFileSync('dist/manifest.json', 'utf8'));
+const REQUIRED_FIELDS = [
+    'id',
+    'label',
+    'plan',
+    'platforms',
+    'risk',
+    'releaseStage',
+    'defaultEnabled',
+    'entitlementFeature',
+    'localKillSwitchKey',
+    'remoteFlagKey',
+    'manifestPermissionsWhenEnabled',
+    'permissionCandidatesAfterReview',
+    'dataClass',
+    'uiSurface'
+];
+
+assert.strictEqual(PUBLIC_MODULE_REGISTRY_VERSION, 1);
+assert.deepStrictEqual(GHOSTIFY_MODULE_IDS, ['ghostMode']);
+assert.strictEqual(GHOSTIFY_MODULES.length, 1, 'public registry should contain Free/Core modules only');
+assert.strictEqual(getGhostifyModule('ghostMode'), GHOSTIFY_MODULES[0]);
+assert.strictEqual(getGhostifyModule('unknownModule'), null);
+
+const ids = new Set();
+for (const moduleEntry of GHOSTIFY_MODULES) {
+    for (const field of REQUIRED_FIELDS) {
+        assert(
+            Object.prototype.hasOwnProperty.call(moduleEntry, field),
+            `registry entry ${moduleEntry.id || '<unknown>'} must include ${field}`
+        );
+    }
+
+    assert(!ids.has(moduleEntry.id), `duplicate module id: ${moduleEntry.id}`);
+    ids.add(moduleEntry.id);
+    assert.strictEqual(moduleEntry.plan, 'free', `${moduleEntry.id} must stay Free/Core`);
+    assert.strictEqual(moduleEntry.entitlementFeature, null, `${moduleEntry.id} must not expose entitlement metadata`);
+    assert.strictEqual(moduleEntry.remoteFlagKey, null, `${moduleEntry.id} must not expose remote paid flags`);
+    assert.strictEqual(moduleEntry.requiresAccount, false, `${moduleEntry.id} must not require accounts`);
+    assert.strictEqual(moduleEntry.requiresRemoteService, false, `${moduleEntry.id} must not require remote services`);
+    assert.deepStrictEqual(moduleEntry.permissionCandidatesAfterReview, []);
+    assert(Array.isArray(moduleEntry.firstReleasePlatforms), `${moduleEntry.id} must include firstReleasePlatforms`);
+    assert(Array.isArray(moduleEntry.plannedPlatforms), `${moduleEntry.id} must include plannedPlatforms`);
+
+    for (const permission of moduleEntry.manifestPermissionsWhenEnabled) {
+        assert(
+            manifest.permissions.includes(permission),
+            `${moduleEntry.id} references manifest permission not present in dist/manifest.json: ${permission}`
+        );
+    }
+}
+
+const ghostMode = getGhostifyModule('ghostMode');
+assert.deepStrictEqual(ghostMode.platforms, ['instagram', 'messenger', 'facebook']);
+assert.deepStrictEqual(ghostMode.firstReleasePlatforms, ['instagram', 'messenger', 'facebook']);
+assert.deepStrictEqual(ghostMode.settingsKeys, FREE_PRIVACY_SETTING_KEYS);
+assert.deepStrictEqual(ghostMode.defaultSettings, DEFAULT_PRIVACY_SETTINGS);
+assert.strictEqual(ghostMode.storageKey, 'ghostifySettings');
+assert.strictEqual(ghostMode.defaultEnabled, true);
+assert.strictEqual(ghostMode.localKillSwitchKey, 'ghostMode');
+assert.strictEqual(ghostMode.uiSurface, 'popup');
+
+const publicRegistrySource = fs.readFileSync('src/modules/registry.js', 'utf8');
+const generatedRuntimeSources = [
+    'dist/background.js',
+    'dist/js/content.js',
+    'dist/js/ghost.js',
+    'dist/js/messenger_patch.js'
+].map(file => fs.readFileSync(file, 'utf8')).join('\n');
+
+assert(!/plan:\s*['"]pro['"]/.test(publicRegistrySource), 'public registry must not contain paid plan entries');
+assert(!/entitlementFeature:\s*['"][^'"]+['"]/.test(publicRegistrySource), 'public registry must not expose entitlement feature names');
+assert(!/remoteFlagKey:\s*['"][^'"]+['"]/.test(publicRegistrySource), 'public registry must not expose remote paid flags');
+assert(!/\b(billing|checkout|subscription|locked|upgrade|paywall)\b/i.test(publicRegistrySource), 'public registry must not contain paid-facing copy');
+assert(!/\b(billing|checkout|subscription|paywall)\b/i.test(generatedRuntimeSources), 'generated Free/Core runtime must not contain paid-service copy');
+
+console.log('module registry contract tests passed');

--- a/test/settings-defaults.test.js
+++ b/test/settings-defaults.test.js
@@ -1,0 +1,177 @@
+const assert = require('assert');
+const fs = require('fs');
+const vm = require('vm');
+const { loadSrcModule } = require('./helpers/load-src-module');
+
+const {
+    DEFAULT_MODULE_FLAGS,
+    DEFAULT_PRIVACY_SETTINGS,
+    FREE_PRIVACY_SETTING_KEYS
+} = loadSrcModule('src/settings/defaults.js');
+const {
+    GHOSTIFY_SETTINGS_STORAGE_KEY,
+    normalizePrivacySettings,
+    sanitizePrivacySettingsForPage
+} = loadSrcModule('src/settings/storage.js');
+
+const EXPECTED_PRIVACY_SETTINGS = {
+    igTyping: true,
+    igSeen: true,
+    igStory: true,
+    msgTyping: true,
+    msgSeen: true,
+    msgStory: true
+};
+const EXPECTED_PRIVACY_KEYS = Object.keys(EXPECTED_PRIVACY_SETTINGS);
+
+assert.deepStrictEqual(FREE_PRIVACY_SETTING_KEYS, EXPECTED_PRIVACY_KEYS);
+assert.deepStrictEqual(DEFAULT_PRIVACY_SETTINGS, EXPECTED_PRIVACY_SETTINGS);
+assert.deepStrictEqual(DEFAULT_MODULE_FLAGS, { ghostMode: true });
+assert.strictEqual(GHOSTIFY_SETTINGS_STORAGE_KEY, 'ghostifySettings');
+
+assert.deepStrictEqual(normalizePrivacySettings(), EXPECTED_PRIVACY_SETTINGS);
+assert.deepStrictEqual(
+    normalizePrivacySettings({
+        igSeen: false,
+        msgTyping: false,
+        ignoredFlag: true,
+        accountId: 'acct_public_test',
+        sessionToken: 'token_public_test'
+    }),
+    {
+        ...EXPECTED_PRIVACY_SETTINGS,
+        igSeen: false,
+        msgTyping: false
+    }
+);
+assert.deepStrictEqual(
+    sanitizePrivacySettingsForPage({
+        igTyping: false,
+        msgStory: false,
+        accountId: 'acct_public_test',
+        sessionToken: 'token_public_test',
+        remotePolicy: { enabled: true }
+    }),
+    {
+        ...EXPECTED_PRIVACY_SETTINGS,
+        igTyping: false,
+        msgStory: false
+    }
+);
+
+for (const settings of [
+    DEFAULT_PRIVACY_SETTINGS,
+    normalizePrivacySettings({ extra: true }),
+    sanitizePrivacySettingsForPage({ extra: true })
+]) {
+    assert.deepStrictEqual(Object.keys(settings), EXPECTED_PRIVACY_KEYS);
+    for (const value of Object.values(settings)) {
+        assert.strictEqual(typeof value, 'boolean');
+    }
+}
+
+assert(
+    fs.readFileSync('src/config.js', 'utf8').includes('DEFAULT_PRIVACY_SETTINGS'),
+    'src/config.js should seed mutable MAIN-world settings from shared defaults'
+);
+assert(
+    fs.readFileSync('src/messenger_patch.js', 'utf8').includes('DEFAULT_PRIVACY_SETTINGS'),
+    'src/messenger_patch.js should seed page-context settings from shared defaults'
+);
+
+const popupSource = fs.readFileSync('dist/js/popup.js', 'utf8');
+const popupDefaultsMatch = popupSource.match(/const DEFAULT_SETTINGS\s*=\s*({[\s\S]*?});/);
+assert(popupDefaultsMatch, 'dist/js/popup.js should keep popup defaults until popup source migration');
+const popupDefaults = vm.runInNewContext(`(${popupDefaultsMatch[1]})`, Object.create(null));
+assert.deepStrictEqual(JSON.parse(JSON.stringify(popupDefaults)), EXPECTED_PRIVACY_SETTINGS);
+
+const settingsMessages = [];
+const storageChangeListeners = [];
+const messageListeners = [];
+const storedSettings = {
+    igSeen: false,
+    msgTyping: false,
+    accountId: 'acct_public_test',
+    sessionToken: 'token_public_test',
+    hiddenObject: { enabled: true }
+};
+const contentContext = {
+    console,
+    Promise,
+    setTimeout(callback) {
+        callback();
+        return 0;
+    },
+    fetch() {
+        return Promise.resolve({ ok: false });
+    },
+    postMessage(message) {
+        settingsMessages.push(message);
+    },
+    addEventListener(type, listener) {
+        if (type === 'message') messageListeners.push(listener);
+    },
+    chrome: {
+        runtime: {
+            getURL(file) {
+                return `chrome-extension://ghostify/${file}`;
+            }
+        },
+        storage: {
+            local: {
+                get(keys, callback) {
+                    if (keys.includes(GHOSTIFY_SETTINGS_STORAGE_KEY)) {
+                        callback({ [GHOSTIFY_SETTINGS_STORAGE_KEY]: storedSettings });
+                        return;
+                    }
+                    callback({});
+                },
+                set() { }
+            },
+            onChanged: {
+                addListener(listener) {
+                    storageChangeListeners.push(listener);
+                }
+            }
+        }
+    }
+};
+contentContext.window = contentContext;
+
+vm.runInNewContext(fs.readFileSync('dist/js/content.js', 'utf8'), contentContext, {
+    filename: 'dist/js/content.js'
+});
+
+assert(messageListeners.length, 'content script should listen for page settings requests');
+assert(storageChangeListeners.length, 'content script should listen for settings storage changes');
+
+storageChangeListeners[0](
+    {
+        [GHOSTIFY_SETTINGS_STORAGE_KEY]: {
+            newValue: {
+                igStory: false,
+                msgSeen: false,
+                accountId: 'acct_public_change',
+                sessionToken: 'token_public_change'
+            }
+        }
+    },
+    'local'
+);
+
+const pageSettingsMessages = settingsMessages.filter(
+    message => message?.type === 'GHOSTIFY_SETTINGS_UPDATE' && message.source === 'GHOSTIFY_EXTENSION'
+);
+assert(pageSettingsMessages.length >= 2, 'content script should bridge initial and changed Free settings');
+
+for (const message of pageSettingsMessages) {
+    assert.deepStrictEqual(Object.keys(message.settings), EXPECTED_PRIVACY_KEYS);
+    for (const value of Object.values(message.settings)) {
+        assert.strictEqual(typeof value, 'boolean');
+    }
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(message.settings, 'accountId'), false);
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(message.settings, 'sessionToken'), false);
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(message.settings, 'hiddenObject'), false);
+}
+
+console.log('settings defaults and page bridge tests passed');

--- a/test/validate-extension-package.test.js
+++ b/test/validate-extension-package.test.js
@@ -94,6 +94,24 @@ withFixture(fixtureRoot => {
 });
 
 withFixture(fixtureRoot => {
+    const contentPath = path.join(fixtureRoot, 'src', 'content.js');
+    const source = fs.readFileSync(contentPath, 'utf8');
+    assert(
+        !source.includes('const DEFAULT_SETTINGS'),
+        'validator fixture should cover the moved DEFAULT_SETTINGS layout'
+    );
+    fs.writeFileSync(contentPath, source.replace('version: "2.0.4"', 'version: "0.0.0"'));
+
+    const result = runValidator(fixtureRoot);
+    assert.notStrictEqual(result.status, 0, 'validator should still parse moved FALLBACK_CONFIG layout');
+    assert.match(
+        result.stderr,
+        /src\/content\.js fallback config version 0\.0\.0 does not match package\.json 2\.0\.4/,
+        result.stderr || result.stdout
+    );
+});
+
+withFixture(fixtureRoot => {
     const result = runValidatorFrom(
         path.dirname(fixtureRoot),
         path.join(fixtureRoot, 'scripts', 'validate-extension-package.js')


### PR DESCRIPTION
## Summary
- add shared Free/Core privacy setting defaults and storage normalization helpers
- add a Free-only module registry contract for Ghost Mode
- sanitize page-bridge settings to the six existing Free privacy booleans
- add module/settings regression tests and update fallback-config validation after moving defaults
- rebuild generated extension bundles

## Validation
- `npm test`
- `npm run validate:extension`
- `npm run verify:dist`

## Manual verification
- `GH-POPUP-001` popup toggle smoke passed manually before publishing.

No Pro-only module metadata, entitlement client, billing UI, or future feature implementation is included.