### PR TITLE
feat(status): Refresh public status experience

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,11 @@ publish yellow only after review and merge. The latest merged update remains
 active regardless of age. A green proposal is rejected when the recorded Store
 version differs from the verification build.
 
+Public status headlines, summaries, history entries, and calendar semantics
+must follow [docs/PUBLIC_STATUS_GUIDE.md](docs/PUBLIC_STATUS_GUIDE.md). The
+public page describes user impact; internal release instructions and evidence
+language stay in structured fields or maintainer-only workflow.
+
 Optional local guard:
 
 ```bash

--- a/dist/css/popup.css
+++ b/dist/css/popup.css
@@ -1,19 +1,19 @@
 /* Ghostify Popup Styles */
 
 :root {
-    --ghost-bg: #0a0a0a;
-    --ghost-surface: #111111;
-    --ghost-panel: #171717;
-    --ghost-panel-high: #1e1e1e;
-    --ghost-line: #242424;
-    --ghost-text: #f0eceb;
-    --ghost-muted: #7a7270;
-    --ghost-soft: #c9a49e;
-    --ghost-red: #e50914;
-    --ghost-red-glow: rgba(229, 9, 20, 0.35);
-    --status-green: #2ee58d;
-    --status-yellow: #f1bd4b;
-    --ghost-off: #252525;
+    --ghost-bg: #e9e4d7;
+    --ghost-surface: #f3eee2;
+    --ghost-panel: rgba(233, 228, 215, 0.72);
+    --ghost-panel-high: #f3eee2;
+    --ghost-line: rgba(15, 15, 13, 0.14);
+    --ghost-text: #0f0f0d;
+    --ghost-muted: rgba(15, 15, 13, 0.58);
+    --ghost-soft: #8873cf;
+    --ghost-red: #0f0f0d;
+    --ghost-red-glow: rgba(136, 115, 207, 0.24);
+    --status-green: #27835f;
+    --status-yellow: #c98b20;
+    --ghost-off: #d7d0c1;
 }
 
 * {
@@ -50,8 +50,8 @@ a {
 .popup-shell {
     width: 320px;
     background: var(--ghost-surface);
-    border: 1px solid #1c1c1c;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    border: 1px solid var(--ghost-line);
+    box-shadow: none;
 }
 
 /* ── Header ───────────────────────────────────── */
@@ -77,11 +77,11 @@ a {
 
 .brand-link:hover h1,
 .brand-link:focus-visible h1 {
-    color: #ffffff;
+    color: var(--ghost-soft);
 }
 
 .brand-link:focus-visible {
-    outline: 2px solid rgba(229, 9, 20, 0.65);
+    outline: 2px solid var(--ghost-soft);
     outline-offset: 4px;
 }
 
@@ -90,6 +90,7 @@ a {
     height: 24px;
     flex: 0 0 auto;
     opacity: 0.95;
+    filter: invert(1);
 }
 
 .header h1 {
@@ -114,26 +115,26 @@ a {
     min-width: 72px;
     min-height: 28px;
     padding: 5px 9px;
-    border: 1px solid #2d2d2d;
-    border-radius: 8px;
-    color: #dedad9;
-    background: linear-gradient(180deg, #1b1b1b, #151515);
+    border: 1px solid var(--ghost-line);
+    border-radius: 999px;
+    color: var(--ghost-text);
+    background: rgba(243, 238, 226, 0.72);
 }
 
 .header-verification:hover,
 .header-verification:focus-visible {
-    color: #ffffff;
-    border-color: #38302e;
-    background: #222222;
+    color: var(--ghost-text);
+    border-color: rgba(136, 115, 207, 0.58);
+    background: var(--ghost-surface);
     outline: none;
 }
 
 .header-verification:focus-visible {
-    box-shadow: 0 0 0 2px rgba(229, 9, 20, 0.65);
+    box-shadow: 0 0 0 2px rgba(136, 115, 207, 0.22);
 }
 
 .verification-summary {
-    color: #dedad9;
+    color: var(--ghost-text);
     font-size: 11px;
     font-weight: 700;
     line-height: 1;
@@ -146,12 +147,12 @@ a {
     flex: 0 0 auto;
     border-radius: 50%;
     background: var(--status-yellow);
-    box-shadow: 0 0 0 3px rgba(241, 189, 75, 0.1), 0 0 10px rgba(241, 189, 75, 0.25);
+    box-shadow: none;
 }
 
 .header-verification[data-status="verified"] .status-icon {
     background: var(--status-green);
-    box-shadow: 0 0 0 3px rgba(46, 229, 141, 0.1), 0 0 10px rgba(46, 229, 141, 0.28);
+    box-shadow: none;
 }
 
 /* ── Platform sections ────────────────────────── */
@@ -214,7 +215,7 @@ a {
 }
 
 .platform-heading-link:focus-visible {
-    box-shadow: 0 0 0 2px rgba(229, 9, 20, 0.55);
+    box-shadow: 0 0 0 2px rgba(136, 115, 207, 0.34);
 }
 
 /* ── Card ─────────────────────────────────────── */
@@ -222,8 +223,8 @@ a {
 .card {
     overflow: visible;
     background: var(--ghost-panel);
-    border: 1px solid #262626;
-    border-radius: 7px;
+    border: 1px solid var(--ghost-line);
+    border-radius: 10px;
 }
 
 /* ── Row ──────────────────────────────────────── */
@@ -251,14 +252,14 @@ a {
 }
 
 .row:hover {
-    background: #222222;
+    background: rgba(136, 115, 207, 0.08);
 }
 
 .row-label {
     display: inline-flex;
     align-items: center;
     gap: 9px;
-    color: #dedad9;
+    color: var(--ghost-text);
     font-size: 13px;
     font-weight: 400;
     line-height: 1;
@@ -273,10 +274,10 @@ a {
     height: 15px;
     flex: 0 0 auto;
     padding: 0;
-    border: 1px solid #58514f;
+    border: 1px solid rgba(15, 15, 13, 0.28);
     border-radius: 50%;
-    color: #bcb3b0;
-    background: #202020;
+    color: var(--ghost-muted);
+    background: transparent;
     appearance: none;
     font-size: 10px;
     font-weight: 700;
@@ -288,9 +289,9 @@ a {
 
 .info-icon:hover,
 .info-icon:focus-visible {
-    color: #ffffff;
+    color: var(--ghost-text);
     border-color: var(--ghost-soft);
-    background: #2a2524;
+    background: rgba(136, 115, 207, 0.1);
     outline: none;
 }
 
@@ -464,7 +465,7 @@ a {
     position: absolute;
     inset: 0;
     cursor: pointer;
-    border: 1px solid #303030;
+    border: 1px solid rgba(15, 15, 13, 0.2);
     border-radius: 999px;
     background: var(--ghost-off);
     transition: background 150ms ease, border-color 150ms ease, box-shadow 150ms ease;
@@ -478,25 +479,25 @@ a {
     width: 12px;
     height: 12px;
     border-radius: 50%;
-    background: #b8b0ae;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+    background: #f3eee2;
+    box-shadow: none;
     transition: transform 150ms cubic-bezier(0.4, 0, 0.2, 1), background 150ms ease;
 }
 
 input:checked + .track {
     border-color: var(--ghost-red);
     background: var(--ghost-red);
-    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+    box-shadow: none;
 }
 
 input:checked + .track::before {
     transform: translateX(14px);
-    background: #ffffff;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+    background: #8873cf;
+    box-shadow: none;
 }
 
 input:focus-visible + .track {
-    outline: 2px solid rgba(229, 9, 20, 0.65);
+    outline: 2px solid rgba(136, 115, 207, 0.72);
     outline-offset: 2px;
 }
 
@@ -522,7 +523,7 @@ input:checked:active + .track::before {
     gap: 12px;
     height: 34px;
     padding: 0 14px;
-    color: #5a5856;
+    color: var(--ghost-muted);
     background: var(--ghost-bg);
     border-top: 1px solid var(--ghost-line);
     font-size: 10px;
@@ -541,7 +542,7 @@ input:checked:active + .track::before {
 .footer-link,
 .support-link {
     position: relative;
-    color: #68615f;
+    color: var(--ghost-muted);
     border-radius: 5px;
     font-weight: 500;
     letter-spacing: 0.02em;
@@ -554,14 +555,14 @@ input:checked:active + .track::before {
 .footer-link:focus-visible,
 .support-link:hover,
 .support-link:focus-visible {
-    color: #b8b0ae;
+    color: var(--ghost-text);
     outline: none;
     text-decoration: underline;
 }
 
 .footer-link:focus-visible,
 .support-link:focus-visible {
-    box-shadow: 0 0 0 2px rgba(229, 9, 20, 0.65);
+    box-shadow: 0 0 0 2px rgba(136, 115, 207, 0.38);
 }
 
 .footer-link::after,

--- a/docs/PUBLIC_STATUS_GUIDE.md
+++ b/docs/PUBLIC_STATUS_GUIDE.md
@@ -1,0 +1,51 @@
+# Public status writing and data guide
+
+Ghostify's status pages are written for people using the extension. They are
+not release notes, maintainer reminders, or instructions to ourselves.
+
+## Write from the user's point of view
+
+- Lead with what a user may experience.
+- Say what is happening now and when another update can be expected.
+- Use calm, direct language: “Some users may…” or “We are investigating…”
+- Avoid internal imperatives and workflow terms such as “must be published,”
+  “maintainer-approved,” “repository proof,” or “verification build pending.”
+- Keep each history entry contemporaneous. An entry may only state what was
+  known on its recorded date; it must not describe a future outcome.
+- Put internal evidence, reviewer, and release information in structured data,
+  not in the public headline or summary.
+
+## Calendar meaning
+
+The status calendar is an event ledger, not a claim that Ghostify was manually
+tested every day.
+
+- **No known issue** means the latest recorded update was healthy and no newer
+  issue had been recorded by that date.
+- **Under review** means the latest recorded update was being investigated or
+  rolled out.
+- **Known issue** means an issue was publicly recorded and had not yet been
+  followed by a resolved or healthy update.
+- **No update** means there was not yet enough public status history to infer a
+  state for that date.
+- Dates before the Chrome Web Store launch and future dates are visually
+  distinct and never presented as working.
+
+The calendar reads its launch date, generated date, history events, and status
+values from `site/src/app/statusData.json`. It renders every month of the
+selected year and adds new years automatically. Do not hard-code a rolling
+month range in the component.
+
+Each history record also has an `eventType`. Use `release` or `fix` for positive
+product updates, `verification` for a routine check, `incident` for confirmed
+breakage, and `investigation` while reports are being reviewed. The calendar
+uses this field so a fix or release never looks identical to a routine check.
+
+## Updating status
+
+1. Add a dated entry to `history` using the user-facing rules above.
+2. Update `summary` to describe the current user impact.
+3. Update platform entries and structured evidence fields when checks change.
+4. Keep `release.publishedAt` as the original Store launch date.
+5. Run the site build and inspect `/status` and `/status/history` at desktop,
+   tablet, and phone widths.

--- a/scripts/prepare-status-update.js
+++ b/scripts/prepare-status-update.js
@@ -19,21 +19,27 @@ const QA_IDS = {
 const YELLOW_MODES = {
     reported: {
         publicStatus: 'under_review',
+        eventType: 'investigation',
         label: 'Reports received',
         title: 'Bug reports received',
-        recordPrefix: 'Reports recorded'
+        recordPrefix: 'Reports recorded',
+        message: labels => `We’re looking into reports affecting ${labels}. We’ll share another update as we learn more.`
     },
     'in-progress': {
         publicStatus: 'work_in_progress',
+        eventType: 'investigation',
         label: 'Working on it',
         title: 'Fix work in progress',
-        recordPrefix: 'Work in progress recorded'
+        recordPrefix: 'Work in progress recorded',
+        message: labels => `We’ve identified an issue affecting ${labels} and are working on a fix.`
     },
     'known-issue': {
         publicStatus: 'known_issue',
+        eventType: 'incident',
         label: 'Known issue',
         title: 'Issue confirmed',
-        recordPrefix: 'Known issue recorded'
+        recordPrefix: 'Known issue recorded',
+        message: labels => `Some users may have trouble with ${labels}. We’re working on it.`
     }
 };
 
@@ -142,8 +148,8 @@ function prepareVerifiedStatus(input, { date, generatedAt }) {
     status.generatedAt = generatedAt;
     status.summary = {
         publicStatus: 'maintainer_verified',
-        label: `Verified ${longDate}`,
-        message: `The maintainer confirmed that all supported controls are working on ${longDate}.`
+        label: 'All supported controls operational',
+        message: `All supported controls were checked on ${longDate} and are working normally.`
     };
 
     status.entries = status.entries.map(entry => {
@@ -165,8 +171,9 @@ function prepareVerifiedStatus(input, { date, generatedAt }) {
     prependHistory(status, {
         date,
         publicStatus: 'maintainer_verified',
-        title: 'All supported controls verified',
-        summary: `The maintainer confirmed that all supported controls are working on v${status.productVersion}.`
+        eventType: 'verification',
+        title: 'All supported controls operational',
+        summary: `All supported controls were checked on ${longDate} and are working normally.`
     });
 
     return status;
@@ -201,7 +208,7 @@ function prepareYellowStatus(input, { mode, date, generatedAt, featureIds, issue
         };
     });
 
-    const defaultMessage = `${modeConfig.label} for ${affectedLabels.join(', ')}.`;
+    const defaultMessage = modeConfig.message(affectedLabels.join(', '));
     status.summary = {
         publicStatus: modeConfig.publicStatus,
         label: modeConfig.label,
@@ -210,6 +217,7 @@ function prepareYellowStatus(input, { mode, date, generatedAt, featureIds, issue
     prependHistory(status, {
         date,
         publicStatus: modeConfig.publicStatus,
+        eventType: modeConfig.eventType,
         title: modeConfig.title,
         summary: note || defaultMessage
     });

--- a/scripts/validate-extension-package.js
+++ b/scripts/validate-extension-package.js
@@ -442,12 +442,15 @@ function assertStatusJsonContract() {
     assertObject(statusJson.release, 'site/src/app/statusData.json release');
     assertOnlyKeys(statusJson.release, [
         'channel',
+        'publishedAt',
         'publishedVersion',
         'checkedAt',
         'matchesVerificationBuild',
         'storeUrl'
     ], 'site/src/app/statusData.json release');
     assertEqual(statusJson.release.channel, 'Chrome Web Store', 'site/src/app/statusData.json release.channel');
+    assertIsoDate(statusJson.release.publishedAt, 'site/src/app/statusData.json release.publishedAt');
+    assertEqual(statusJson.release.publishedAt, '2026-02-06', 'site/src/app/statusData.json release.publishedAt');
     if (!statusJson.release.publishedVersion || typeof statusJson.release.publishedVersion !== 'string') {
         fail('site/src/app/statusData.json release.publishedVersion must be a non-empty string');
     }
@@ -606,9 +609,10 @@ function assertStatusJsonContract() {
     for (const [index, item] of statusJson.history.entries()) {
         const label = `site/src/app/statusData.json history[${index}]`;
         assertObject(item, label);
-        assertOnlyKeys(item, ['date', 'publicStatus', 'title', 'summary'], label);
+        assertOnlyKeys(item, ['date', 'publicStatus', 'eventType', 'title', 'summary'], label);
         assertNullableIsoDate(item.date, `${label}.date`);
         assertEnum(item.publicStatus, PUBLIC_STATUS_VALUES, `${label}.publicStatus`);
+        assertEnum(item.eventType, ['release', 'fix', 'verification', 'incident', 'investigation'], `${label}.eventType`);
         if (!item.title || typeof item.title !== 'string') fail(`${label}.title must be a non-empty string`);
         if (!item.summary || typeof item.summary !== 'string') fail(`${label}.summary must be a non-empty string`);
         if (Date.parse(`${item.date}T00:00:00Z`) > Date.parse(statusJson.generatedAt)) {
@@ -620,6 +624,24 @@ function assertStatusJsonContract() {
     }
     if (statusJson.history[0].publicStatus !== statusJson.summary.publicStatus) {
         fail('site/src/app/statusData.json summary.publicStatus must match the latest history record');
+    }
+
+    const publicCopy = [
+        statusJson.summary.label,
+        statusJson.summary.message,
+        ...statusJson.history.flatMap(item => [item.title, item.summary])
+    ];
+    const internalPhrases = [
+        /\bmust be published\b/i,
+        /\bmaintainer-approved\b/i,
+        /\brepository (?:build|proof|evidence)\b/i,
+        /\bverification build pending\b/i,
+        /\bstatus-enabled store build\b/i
+    ];
+    for (const phrase of internalPhrases) {
+        if (publicCopy.some(value => phrase.test(value))) {
+            fail(`site/src/app/statusData.json public copy contains internal workflow language: ${phrase}`);
+        }
     }
 }
 

--- a/site/src/app/components/HomePage.tsx
+++ b/site/src/app/components/HomePage.tsx
@@ -81,11 +81,7 @@ const PLATFORMS: Array<{
   { platform: 'facebook', name: 'Facebook', url: 'facebook.com', qualifier: 'Shared settings with Messenger' },
 ];
 
-const AI_PROMPT = [
-  'Give me an independent assessment of Ghostify, a browser extension for supported Seen, Typing, and Story View controls on Instagram, Messenger, and Facebook.',
-  'Review its public website at https://ghostify-extension.vercel.app and source at https://github.com/Hendrizzzz/Ghostify.',
-  'Explain what it does, its privacy model, important limitations, and whether its public claims are supported by the available evidence.',
-].join(' ');
+const AI_PROMPT = 'Hey, what do you think of Ghostify? Take a quick look at https://ghostify-extension.vercel.app and tell me what it does, who it is for, and anything useful to know before installing it.';
 
 const AI_LINKS = [
   { name: 'ChatGPT', href: `https://chatgpt.com/?q=${encodeURIComponent(AI_PROMPT)}` },
@@ -473,7 +469,7 @@ function FootprintSection() {
     <section className="footprint-section" ref={sectionRef}>
       <header>
         <h2>Small enough to stay out of the way.</h2>
-        <p>Measured from the current 2.0.4 build—not an old marketing number.</p>
+        <p>A quick look at the current v2.0.4 build.</p>
       </header>
       <div className="footprint-metrics">
         <article><strong>{packageSize.toFixed(1)}<span>KiB</span></strong><small>installed package</small></article>
@@ -583,9 +579,15 @@ function FeatureScroll() {
 
         <figure className="feature-scroll-media" key={`media-${activeFeature.platform}`}>
           <div className="feature-media-frame">
-            <div className="feature-media-meta" aria-hidden="true">
-              <span><ShieldCheck size={14} />Signal held before send</span>
-              <span><i />Original Ghostify capture</span>
+            <div className={`feature-media-sketch feature-media-sketch-${activeFeature.platform}`} aria-hidden="true">
+              <svg viewBox="0 0 760 104" preserveAspectRatio="none">
+                <path d="M8 74C152 74 212 18 354 30C478 40 557 86 752 38" />
+                <circle cx="8" cy="74" r="4" />
+                <circle cx="752" cy="38" r="4" />
+              </svg>
+              <span className="feature-sketch-platform" />
+              <span className="feature-sketch-ghost"><GhostMark size={58} bodyColor="#0f0f0d" eyeColor="#f3eee2" /></span>
+              <span className="feature-sketch-spark">✦</span>
             </div>
             <img
               src={activeFeature.src}

--- a/site/src/app/components/StatusPage.tsx
+++ b/site/src/app/components/StatusPage.tsx
@@ -8,6 +8,7 @@ import {
   History,
   Info,
 } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import {
   STATUS_DATA,
   STATUS_LABELS,
@@ -166,7 +167,7 @@ function CurrentNotice() {
         <p>{message}</p>
         {releaseMismatch && (
           <p className="status-secondary-warning">
-            The Store also publishes v{STATUS_DATA.release.publishedVersion}, while these records describe repository build v{STATUS_DATA.productVersion}.
+            Chrome Web Store v{STATUS_DATA.release.publishedVersion} does not include live popup status yet. You can continue checking this page for updates.
           </p>
         )}
         {releaseMismatch && (
@@ -185,19 +186,178 @@ function CurrentNotice() {
   );
 }
 
-function StatusRail({ entries }: { entries: readonly VerificationEntry[] }) {
-  const segments = FEATURES.flatMap((feature) => {
-    const entry = getFeatureEntry(entries, feature);
-    const status = entry ? getEffectiveStatus(entry) : 'public_status_unavailable';
-    const tone = STATUS_META[status].tone;
-    return Array.from({ length: 10 }, (_, index) => (tone === 'warn' && index % 3 !== 0 ? 'muted' : tone));
+type TimelineTone = 'clear' | 'update' | 'issue' | 'review' | 'quiet' | 'outside' | 'upcoming';
+
+type TimelineDay = {
+  date: string;
+  tone: TimelineTone;
+  label: string;
+  detail: string;
+  column: number;
+  row: number;
+};
+
+function toDateKey(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function toneForStatus(status: PublicVerificationStatus): TimelineTone {
+  if (status === 'known_issue') return 'issue';
+  if (status === 'under_review' || status === 'work_in_progress') return 'review';
+  if (status === 'maintainer_verified' || status === 'community_verified_reviewed') return 'clear';
+  return 'quiet';
+}
+
+function toneForEvent(event: (typeof STATUS_DATA.history)[number]): TimelineTone {
+  if (event.eventType === 'release' || event.eventType === 'fix') return 'update';
+  return toneForStatus(event.publicStatus);
+}
+
+function buildTimelineDays(year: number, today: Date): TimelineDay[] {
+  const launchTime = Date.parse(`${STATUS_DATA.release.publishedAt}T00:00:00Z`);
+  const yearStart = new Date(Date.UTC(year, 0, 1));
+  const calendarStart = new Date(yearStart);
+  calendarStart.setUTCDate(calendarStart.getUTCDate() - calendarStart.getUTCDay());
+  const events = [...STATUS_DATA.history].sort((left, right) => Date.parse(left.date) - Date.parse(right.date));
+  const eventByDate = new Map(events.map((event) => [event.date, event]));
+  const cellCount = 54 * 7;
+
+  return Array.from({ length: cellCount }, (_, index) => {
+    const current = new Date(calendarStart);
+    current.setUTCDate(calendarStart.getUTCDate() + index);
+    const date = toDateKey(current);
+    const time = current.getTime();
+    const inYear = current.getUTCFullYear() === year;
+    const event = eventByDate.get(date);
+    const latestEvent = events.filter((item) => Date.parse(item.date) <= time).at(-1);
+    let tone: TimelineTone = 'quiet';
+    let label = 'No status update recorded';
+    let detail = 'There was no public status update recorded for this day.';
+
+    if (!inYear || time < launchTime) {
+      tone = 'outside';
+      label = time < launchTime ? 'Before the Chrome Web Store launch' : 'Outside this year';
+      detail = time < launchTime
+        ? `Ghostify launched on the Chrome Web Store on ${formatStatusDate(STATUS_DATA.release.publishedAt)}.`
+        : 'This date is outside the selected year.';
+    } else if (time > today.getTime()) {
+      tone = 'upcoming';
+      label = 'Upcoming date';
+      detail = 'No status is available for a future date.';
+    } else if (latestEvent) {
+      tone = toneForStatus(latestEvent.publicStatus);
+      label = tone === 'clear' ? 'No known issue recorded' : tone === 'issue' ? 'Known issue' : 'Under review';
+      detail = tone === 'clear'
+        ? 'No newer issue was recorded after the latest status update.'
+        : latestEvent.summary;
+    }
+
+    if (event) {
+      tone = toneForEvent(event);
+      label = event.title;
+      detail = event.summary;
+    }
+
+    return {
+      date,
+      tone,
+      label,
+      detail,
+      column: Math.floor(index / 7) + 1,
+      row: (index % 7) + 1,
+    };
   });
+}
+
+function VerificationTimeline() {
+  const today = useMemo(() => {
+    const now = new Date();
+    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  }, []);
+  const launchYear = new Date(`${STATUS_DATA.release.publishedAt}T00:00:00Z`).getUTCFullYear();
+  const currentYear = Math.max(launchYear, today.getUTCFullYear());
+  const years = Array.from({ length: currentYear - launchYear + 1 }, (_, index) => currentYear - index);
+  const [selectedYear, setSelectedYear] = useState(currentYear);
+  const days = useMemo(() => buildTimelineDays(selectedYear, today), [selectedYear, today]);
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
+  const selected = selectedDate
+    ? days.find((day) => day.date === selectedDate && day.date.startsWith(`${selectedYear}-`)) ?? null
+    : null;
+  const latestUpdate = STATUS_DATA.history[0];
+  const detail = selected ?? {
+    date: latestUpdate.date,
+    tone: toneForEvent(latestUpdate),
+    label: latestUpdate.title,
+    detail: latestUpdate.summary,
+  };
+  const months = useMemo(() => Array.from({ length: 12 }, (_, month) => {
+    const first = new Date(Date.UTC(selectedYear, month, 1));
+    const firstFullWeek = new Date(first);
+    firstFullWeek.setUTCDate(first.getUTCDate() + ((7 - first.getUTCDay()) % 7));
+    const firstCell = days.find((day) => day.date === toDateKey(firstFullWeek));
+    return {
+      label: new Intl.DateTimeFormat('en', { month: 'short', timeZone: 'UTC' }).format(first),
+      column: firstCell?.column ?? 1,
+    };
+  }), [days, selectedYear]);
+
+  const changeYear = (year: number) => {
+    setSelectedYear(year);
+    setSelectedDate(null);
+  };
 
   return (
-    <div className="status-rail" aria-hidden="true">
-      {segments.map((tone, index) => (
-        <span className={`status-rail-segment status-rail-${tone}`} key={index} />
-      ))}
+    <div className="status-timeline" aria-label="Dated verification timeline">
+      <div className="status-timeline-head">
+        <div>
+          <strong>Status calendar</strong>
+          <span>From the Chrome Web Store launch to today</span>
+        </div>
+        <div className="status-timeline-years" aria-label="Choose a status year">
+          {years.map((year) => (
+            <button type="button" className={year === selectedYear ? 'is-active' : undefined} onClick={() => changeYear(year)} key={year}>
+              {year}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="status-timeline-legend" aria-hidden="true">
+        <span className="is-clear">No known issue</span>
+        <span className="is-update">Product update</span>
+        <span className="is-review">Under review</span>
+        <span className="is-issue">Known issue</span>
+        <span className="is-quiet">No update</span>
+      </div>
+      <div className="status-calendar-wrap">
+        <div className="status-calendar-months" aria-hidden="true">
+          {months.map((month) => <span style={{ gridColumn: month.column }} key={month.label}>{month.label}</span>)}
+        </div>
+        <div className="status-calendar-body">
+          <div className="status-calendar-weekdays" aria-hidden="true"><span>Mon</span><span>Wed</span><span>Fri</span></div>
+          <div className={`status-calendar-days${selectedDate ? ' has-selection' : ''}`}>
+            {days.map((day) => (
+              <button
+                type="button"
+                className={`status-calendar-day is-${day.tone}${selectedDate === day.date ? ' is-selected' : ''}${day.column <= 3 ? ' is-tooltip-left' : ''}${day.column >= 52 ? ' is-tooltip-right' : ''}`}
+                style={{ gridColumn: day.column, gridRow: day.row }}
+                aria-label={`${formatStatusDate(day.date)}: ${day.label}`}
+                aria-pressed={selectedDate === day.date}
+                onClick={() => setSelectedDate((current) => current === day.date ? null : day.date)}
+                key={day.date}
+              >
+                <span className="status-calendar-tooltip" role="tooltip">
+                  <b>{formatStatusDate(day.date)}</b>{day.label}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className={`status-timeline-detail is-${detail.tone}`} aria-live="polite">
+        <time>{formatStatusDate(detail.date)}</time>
+        <strong>{detail.label}</strong>
+        <p>{detail.detail}</p>
+      </div>
     </div>
   );
 }
@@ -227,8 +387,6 @@ function PlatformRow({ platform, entries }: { platform: (typeof PLATFORMS)[numbe
         </div>
       </div>
 
-      <StatusRail entries={entries} />
-
       <div className="status-feature-list">
         {FEATURES.map((feature) => {
           const entry = getFeatureEntry(entries, feature);
@@ -254,6 +412,7 @@ function SystemStatus() {
         <h2 id="system-status-heading">Verification build checks</h2>
         <span>Repository v{STATUS_DATA.productVersion}</span>
       </div>
+      <VerificationTimeline />
       <div className="status-platform-list">
         {PLATFORMS.map((platform) => (
           <PlatformRow key={platform.name} platform={platform} entries={grouped[platform.name]} />
@@ -281,8 +440,7 @@ function StatusActions() {
 function StatusFootnote() {
   return (
     <p className="status-footnote">
-      Status is public and evidence is reviewed before a feature turns green. Private messages, credentials, screenshots,
-      and raw submissions are never published.
+      Dated checks are shown here so you can see what was known, and when it was known.
     </p>
   );
 }
@@ -293,9 +451,24 @@ function buildVisibleHistory(): HistoryItem[] {
   return [...STATUS_DATA.history];
 }
 
+function buildHistoryGroups() {
+  const groups = new Map<string, HistoryItem[]>();
+  buildVisibleHistory().forEach((item) => {
+    const key = item.date.slice(0, 7);
+    groups.set(key, [...(groups.get(key) ?? []), item]);
+  });
+  return [...groups.entries()].map(([key, items]) => ({
+    key,
+    label: new Intl.DateTimeFormat('en', { month: 'long', year: 'numeric', timeZone: 'UTC' })
+      .format(new Date(`${key}-01T00:00:00Z`)),
+    items,
+  }));
+}
+
 function CurrentStatus() {
   return (
     <>
+      <a className="status-home-link" href="/"><ArrowLeft size={15} /> Back to Ghostify</a>
       <div className="status-topbar">
         <h1>Ghostify Status</h1>
         <a href="/status/history">View history</a>
@@ -311,12 +484,9 @@ function CurrentStatus() {
 function HistoryStatus() {
   return (
     <>
+      <a className="status-home-link" href="/status"><ArrowLeft size={15} /> Current status</a>
       <div className="status-topbar">
         <h1>Status history</h1>
-        <a href="/status">
-          <ArrowLeft size={15} strokeWidth={1.8} />
-          Current status
-        </a>
       </div>
       <section className="status-panel" aria-labelledby="history-heading">
         <div className="status-panel-head">
@@ -324,16 +494,21 @@ function HistoryStatus() {
           <span>Public record</span>
         </div>
         <div className="status-history-list">
-          {buildVisibleHistory().map((item) => (
-            <article className="status-history-row" key={`${item.date}-${item.title}`}>
-              <StatusIcon status={item.publicStatus} size={16} />
-              <time>{formatStatusDate(item.date)}</time>
-              <div>
-                <strong>{item.title}</strong>
-                <p>{item.summary}</p>
-              </div>
-              <StatusPill status={item.publicStatus} />
-            </article>
+          {buildHistoryGroups().map((group) => (
+            <section className="status-history-group" aria-labelledby={`history-${group.key}`} key={group.key}>
+              <h3 id={`history-${group.key}`}>{group.label}</h3>
+              {group.items.map((item) => (
+                <article className="status-history-row" key={`${item.date}-${item.title}`}>
+                  <StatusIcon status={item.publicStatus} size={16} />
+                  <time>{formatStatusDate(item.date)}</time>
+                  <div>
+                    <strong>{item.title}</strong>
+                    <p>{item.summary}</p>
+                  </div>
+                  <StatusPill status={item.publicStatus} />
+                </article>
+              ))}
+            </section>
           ))}
         </div>
       </section>

--- a/site/src/app/statusData.json
+++ b/site/src/app/statusData.json
@@ -5,6 +5,7 @@
   "generatedAt": "2026-07-12T09:20:13Z",
   "release": {
     "channel": "Chrome Web Store",
+    "publishedAt": "2026-02-06",
     "publishedVersion": "2.0.3",
     "checkedAt": "2026-07-12T09:20:13Z",
     "matchesVerificationBuild": false,
@@ -14,11 +15,11 @@
   "historyUrl": "https://ghostify-extension.vercel.app/status/history",
   "summary": {
     "publicStatus": "under_review",
-    "label": "Store update pending",
-    "message": "The status-enabled v2.0.4 build must be published and verified before installed popups can receive live status updates."
+    "label": "Live status rollout in progress",
+    "message": "Some users may not see live status in the extension popup yet. We’re rolling out an update and will share another update when it’s available."
   },
   "policy": {
-    "verificationCadence": "Updated by a maintainer-approved pull request after reports, work progress, or full verification.",
+    "verificationCadence": "Updated when we receive reports, make progress, or complete new checks.",
     "latestMergedUpdateWins": true,
     "ageDoesNotChangeStatus": true
   },
@@ -167,38 +168,93 @@
     {
       "date": "2026-07-12",
       "publicStatus": "under_review",
-      "title": "Status-enabled Store build pending",
-      "summary": "The status-enabled v2.0.4 build must be published and verified before installed popups can receive live status updates."
+      "eventType": "investigation",
+      "title": "Live status is not yet available in the extension popup",
+      "summary": "Some users may not see live status in the extension popup yet. We’re rolling out an update and will share another update when it’s available."
     },
     {
       "date": "2026-06-27",
       "publicStatus": "maintainer_verified",
-      "title": "All supported controls proven working",
-      "summary": "Maintainer smoke review confirmed the supported controls on repository build v2.0.4. This is historical repository evidence, not proof for the currently published Store build."
+      "eventType": "verification",
+      "title": "Supported controls passed today's review",
+      "summary": "Checked the supported Instagram, Messenger, and Facebook controls on v2.0.4. Every control included in today's review passed."
+    },
+    {
+      "date": "2026-06-10",
+      "publicStatus": "maintainer_verified",
+      "eventType": "release",
+      "title": "Ghostify 2.0.3 published",
+      "summary": "Ghostify 2.0.3 became available on the Chrome Web Store."
+    },
+    {
+      "date": "2026-06-05",
+      "publicStatus": "maintainer_verified",
+      "eventType": "release",
+      "title": "Ghostify 2.0.2 published",
+      "summary": "Ghostify 2.0.2 became available on the Chrome Web Store."
     },
     {
       "date": "2026-06-04",
       "publicStatus": "maintainer_verified",
-      "title": "Fix launched and current working window restarted",
-      "summary": "The fix shipped on June 4, 2026. From this date through June 27, 2026, the supported controls were treated as working again after daily maintainer verification."
+      "eventType": "fix",
+      "title": "Ghostify 2.0.1 published",
+      "summary": "Ghostify 2.0.1 became available on the Chrome Web Store with the Instagram Hide Story Views fix."
     },
     {
       "date": "2026-06-02",
       "publicStatus": "known_issue",
-      "title": "Breakage verified and fix work started",
-      "summary": "The May 29 reports were confirmed on June 2, 2026, and maintainer fix work started from that verified breakage."
+      "eventType": "incident",
+      "title": "Instagram Hide Story Views issue confirmed",
+      "summary": "We confirmed an issue affecting Hide Story Views on Instagram and began working on a fix."
     },
     {
       "date": "2026-05-29",
       "publicStatus": "known_issue",
-      "title": "Breakage reports received",
-      "summary": "Credible reports said Ghostify had broken on supported Meta surfaces, ending the prior green window until the issue was verified and fixed."
+      "eventType": "incident",
+      "title": "Instagram Hide Story Views reports received",
+      "summary": "Some users reported that Hide Story Views was not working on Instagram. We began investigating."
     },
     {
       "date": "2026-02-28",
       "publicStatus": "maintainer_verified",
-      "title": "Previous working window began",
-      "summary": "Ghostify was proven working from February 28, 2026 through May 28, 2026, before the May 29 breakage reports."
+      "eventType": "verification",
+      "title": "Supported controls passed review",
+      "summary": "Completed a review of the supported controls available in this build. The checks performed today passed."
+    },
+    {
+      "date": "2026-02-24",
+      "publicStatus": "maintainer_verified",
+      "eventType": "release",
+      "title": "Ghostify 2.0.0 published",
+      "summary": "Ghostify 2.0.0 became available on the Chrome Web Store."
+    },
+    {
+      "date": "2026-02-17",
+      "publicStatus": "maintainer_verified",
+      "eventType": "release",
+      "title": "Ghostify 1.0.3 published",
+      "summary": "Ghostify 1.0.3 became available on the Chrome Web Store."
+    },
+    {
+      "date": "2026-02-12",
+      "publicStatus": "maintainer_verified",
+      "eventType": "release",
+      "title": "Ghostify 1.0.2 published",
+      "summary": "Ghostify 1.0.2 became available on the Chrome Web Store."
+    },
+    {
+      "date": "2026-02-09",
+      "publicStatus": "maintainer_verified",
+      "eventType": "release",
+      "title": "Ghostify 1.0.1 published",
+      "summary": "Ghostify 1.0.1 became available on the Chrome Web Store."
+    },
+    {
+      "date": "2026-02-06",
+      "publicStatus": "maintainer_verified",
+      "eventType": "release",
+      "title": "Ghostify 1.0.0 published",
+      "summary": "Ghostify became available on the Chrome Web Store."
     }
   ]
 }

--- a/site/src/app/statusData.ts
+++ b/site/src/app/statusData.ts
@@ -35,6 +35,7 @@ export type StatusData = {
   generatedAt: string;
   release: {
     channel: 'Chrome Web Store';
+    publishedAt: string;
     publishedVersion: string;
     checkedAt: string;
     matchesVerificationBuild: boolean;
@@ -69,6 +70,7 @@ export type StatusData = {
   history: Array<{
     date: string;
     publicStatus: PublicVerificationStatus;
+    eventType: 'release' | 'fix' | 'verification' | 'incident' | 'investigation';
     title: string;
     summary: string;
   }>;

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -671,36 +671,73 @@
 
 .feature-media-frame {
   width: min(100%, 760px);
+  position: relative;
+  padding-top: 76px;
 }
 
-.feature-media-meta {
-  min-height: 38px;
-  margin-bottom: 10px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 20px;
-  border-bottom: 1px solid rgba(15, 15, 13, 0.17);
-  color: rgba(15, 15, 13, 0.58);
+.feature-media-sketch {
+  height: 112px;
+  position: absolute;
+  top: 0;
+  left: -15%;
+  right: -2%;
+  pointer-events: none;
 }
 
-.feature-media-meta span {
-  min-height: 30px;
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 0.035em;
-  text-transform: uppercase;
+.feature-media-sketch > svg {
+  width: 100%;
+  height: 100%;
+  overflow: visible;
 }
 
-.feature-media-meta i {
-  width: 6px;
-  height: 6px;
+.feature-media-sketch path {
+  fill: none;
+  stroke: rgba(15, 15, 13, 0.22);
+  stroke-width: 1.25;
+  stroke-dasharray: 3 8;
+}
+
+.feature-media-sketch circle { fill: var(--home-accent); }
+
+.feature-sketch-platform,
+.feature-sketch-ghost,
+.feature-sketch-spark {
+  position: absolute;
+  display: grid;
+  place-items: center;
+}
+
+.feature-sketch-platform {
+  width: 28px;
+  height: 28px;
+  left: 13%;
+  top: 44px;
   border-radius: 50%;
-  background: #26815c;
-  box-shadow: 0 0 0 3px rgba(38, 129, 92, 0.12);
+  background: var(--home-accent);
+}
+
+.feature-sketch-platform::before {
+  color: rgba(15, 15, 13, 0.2);
+  content: '+';
+  font: 500 11px/1 var(--font-sans);
+}
+
+.feature-media-sketch-messenger .feature-sketch-platform { background: #1686ed; }
+.feature-media-sketch-instagram .feature-sketch-platform { background: #d62976; }
+.feature-media-sketch-facebook .feature-sketch-platform { background: #1877f2; }
+.feature-sketch-ghost { right: 22%; top: 3px; transform: rotate(5deg); filter: drop-shadow(8px 8px 0 rgba(136, 115, 207, 0.7)); }
+.feature-sketch-spark { right: 2%; top: 23px; color: var(--home-accent); font-size: 28px; transform: rotate(14deg); }
+
+.feature-media-sketch-messenger .feature-sketch-spark { color: #1686ed; }
+.feature-media-sketch-instagram .feature-sketch-spark { color: #d62976; }
+.feature-media-sketch-facebook .feature-sketch-spark { color: #1877f2; }
+
+@media (max-width: 760px) {
+  .feature-media-frame { padding-top: 54px; }
+  .feature-media-sketch { height: 82px; left: 0; }
+  .feature-sketch-platform { left: 5%; top: 30px; }
+  .feature-sketch-ghost { right: 18%; transform: scale(.82) rotate(5deg); }
+  .feature-sketch-spark { font-size: 22px; }
 }
 
 .feature-scroll-media img {
@@ -2513,6 +2550,28 @@
   width: min(100%, 1280px);
 }
 
+.site-root.is-status-view .status-page .status-home-link {
+  width: fit-content;
+  min-height: 38px;
+  margin-bottom: 26px;
+  padding: 0 13px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid rgba(15, 15, 13, 0.18);
+  border-radius: 999px;
+  color: var(--home-ink);
+  background: rgba(243, 238, 226, 0.72);
+  font: 650 12px/1 var(--font-sans);
+  text-decoration: none;
+  transition: transform 160ms ease, background 160ms ease;
+}
+
+.site-root.is-status-view .status-page .status-home-link:hover {
+  background: var(--home-lavender);
+  transform: translateX(-3px);
+}
+
 .site-root.is-status-view .status-page .status-topbar {
   margin-bottom: 42px;
   align-items: flex-end;
@@ -2593,14 +2652,15 @@
 }
 
 .site-root.is-status-view .status-page .status-notice h2 {
-  max-width: 800px;
+  max-width: none;
   margin-top: 28px;
   color: var(--home-cream);
   font-family: var(--font-editorial);
-  font-size: clamp(2.6rem, 4vw, 4.5rem);
+  font-size: clamp(2.6rem, 3.7vw, 3.8rem);
   font-weight: 430;
   letter-spacing: -0.045em;
   line-height: 0.96;
+  white-space: nowrap;
 }
 
 .site-root.is-status-view .status-page .status-notice p,
@@ -2651,6 +2711,264 @@
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 14px;
+}
+
+.site-root.is-status-view .status-page .status-timeline {
+  margin: 18px 0 0;
+  padding: 22px;
+  border: 1px solid rgba(15, 15, 13, 0.15);
+  border-radius: 20px;
+  background: rgba(243, 238, 226, 0.72);
+  font-family: var(--font-sans);
+}
+
+.site-root.is-status-view .status-page .status-timeline-head {
+  margin-bottom: 18px;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.site-root.is-status-view .status-page .status-timeline-head > div:first-child {
+  display: grid;
+  gap: 4px;
+}
+
+.site-root.is-status-view .status-page .status-timeline-head strong {
+  color: var(--home-ink);
+  font-size: 14px;
+}
+
+.site-root.is-status-view .status-page .status-timeline-head span {
+  color: rgba(15, 15, 13, 0.52);
+  font-size: 11px;
+}
+
+.site-root.is-status-view .status-page .status-timeline-years {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.site-root.is-status-view .status-page .status-timeline-years button {
+  min-height: 30px;
+  padding: 0 11px;
+  border: 1px solid rgba(15, 15, 13, 0.15);
+  border-radius: 999px;
+  color: rgba(15, 15, 13, 0.62);
+  background: transparent;
+  font: 650 11px/1 var(--font-sans);
+  cursor: pointer;
+}
+
+.site-root.is-status-view .status-page .status-timeline-years button.is-active {
+  color: var(--home-cream);
+  background: var(--home-ink);
+}
+
+.site-root.is-status-view .status-page .status-timeline-legend {
+  margin-bottom: 18px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  color: rgba(15, 15, 13, 0.56);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.site-root.is-status-view .status-page .status-timeline-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.site-root.is-status-view .status-page .status-timeline-legend span::before {
+  width: 9px;
+  height: 9px;
+  border-radius: 3px;
+  background: rgba(15, 15, 13, 0.12);
+  content: '';
+}
+
+.site-root.is-status-view .status-page .status-timeline-legend .is-clear::before,
+.site-root.is-status-view .status-page .status-calendar-day.is-clear { background: var(--home-accent); }
+.site-root.is-status-view .status-page .status-timeline-legend .is-update::before,
+.site-root.is-status-view .status-page .status-calendar-day.is-update { background: #278e72; }
+.site-root.is-status-view .status-page .status-timeline-legend .is-review::before,
+.site-root.is-status-view .status-page .status-calendar-day.is-review { background: #b9a8ef; }
+.site-root.is-status-view .status-page .status-timeline-legend .is-issue::before,
+.site-root.is-status-view .status-page .status-calendar-day.is-issue { background: #d85d4a; }
+.site-root.is-status-view .status-page .status-timeline-legend .is-quiet::before,
+.site-root.is-status-view .status-page .status-calendar-day.is-quiet { background: rgba(15, 15, 13, 0.16); }
+.site-root.is-status-view .status-page .status-calendar-day.is-outside { background: transparent; box-shadow: inset 0 0 0 1px rgba(15, 15, 13, 0.12); }
+.site-root.is-status-view .status-page .status-calendar-day.is-upcoming { background: rgba(15, 15, 13, 0.055); }
+
+.site-root.is-status-view .status-page .status-calendar-wrap {
+  width: 100%;
+  margin-top: -46px;
+  padding: 46px 0 10px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.site-root.is-status-view .status-page .status-calendar-wrap::-webkit-scrollbar { display: none; }
+
+.site-root.is-status-view .status-page .status-calendar-months {
+  min-width: 690px;
+  margin-left: 34px;
+  display: grid;
+  grid-template-columns: repeat(54, minmax(8px, 1fr));
+  gap: 3px;
+}
+
+.site-root.is-status-view .status-page .status-calendar-months span {
+  margin-bottom: 7px;
+  color: rgba(15, 15, 13, 0.68);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.site-root.is-status-view .status-page .status-calendar-body {
+  min-width: 724px;
+  padding-bottom: 4px;
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  gap: 6px;
+}
+
+.site-root.is-status-view .status-page .status-calendar-weekdays {
+  height: 102px;
+  display: grid;
+  grid-template-rows: repeat(7, 1fr);
+  align-items: center;
+  color: rgba(15, 15, 13, 0.46);
+  font-size: 9px;
+}
+
+.site-root.is-status-view .status-page .status-calendar-weekdays span:nth-child(1) { grid-row: 2; }
+.site-root.is-status-view .status-page .status-calendar-weekdays span:nth-child(2) { grid-row: 4; }
+.site-root.is-status-view .status-page .status-calendar-weekdays span:nth-child(3) { grid-row: 6; }
+
+.site-root.is-status-view .status-page .status-calendar-days {
+  height: 102px;
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(54, minmax(8px, 1fr));
+  grid-template-rows: repeat(7, minmax(8px, 1fr));
+  gap: 3px;
+}
+
+.site-root.is-status-view .status-page .status-calendar-day {
+  width: 100%;
+  height: 100%;
+  min-width: 8px;
+  min-height: 8px;
+  padding: 0;
+  border: 0;
+  border-radius: 3px;
+  cursor: pointer;
+  overflow: visible;
+  position: relative;
+}
+
+.site-root.is-status-view .status-page .status-calendar-day:hover {
+  z-index: 2;
+  filter: brightness(0.88);
+}
+
+.site-root.is-status-view .status-page .status-calendar-days.has-selection .status-calendar-day:not(.is-selected) {
+  opacity: 0.36;
+}
+
+.site-root.is-status-view .status-page .status-calendar-days.has-selection .status-calendar-day:not(.is-selected):hover,
+.site-root.is-status-view .status-page .status-calendar-days.has-selection .status-calendar-day:not(.is-selected):focus-visible {
+  opacity: 0.78;
+}
+
+.site-root.is-status-view .status-page .status-calendar-day:focus-visible,
+.site-root.is-status-view .status-page .status-calendar-day.is-selected {
+  outline: 0;
+  z-index: 3;
+  box-shadow:
+    0 0 0 2px #6f59c8,
+    0 0 12px rgba(111, 89, 200, 0.5);
+  filter: none;
+  opacity: 1;
+}
+
+.site-root.is-status-view .status-page .status-calendar-tooltip {
+  width: max-content;
+  max-width: 290px;
+  padding: 8px 10px;
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 8px);
+  z-index: 20;
+  display: grid;
+  gap: 3px;
+  border-radius: 8px;
+  color: var(--home-cream);
+  background: var(--home-ink);
+  box-shadow: 0 10px 28px rgba(15, 15, 13, 0.2);
+  font: 600 10px/1.25 var(--font-sans);
+  text-align: left;
+  white-space: normal;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(-50%);
+}
+
+.site-root.is-status-view .status-page .status-calendar-tooltip b {
+  color: var(--home-lavender);
+  font-size: 9px;
+  font-weight: 650;
+}
+
+.site-root.is-status-view .status-page .status-calendar-day:hover .status-calendar-tooltip,
+.site-root.is-status-view .status-page .status-calendar-day:focus-visible .status-calendar-tooltip {
+  opacity: 1;
+  visibility: visible;
+}
+
+.site-root.is-status-view .status-page .status-calendar-day.is-tooltip-left .status-calendar-tooltip {
+  left: 0;
+  transform: none;
+}
+
+.site-root.is-status-view .status-page .status-calendar-day.is-tooltip-right .status-calendar-tooltip {
+  right: 0;
+  left: auto;
+  transform: none;
+}
+
+.site-root.is-status-view .status-page .status-timeline-detail {
+  margin-top: 20px;
+  padding: 16px 18px;
+  display: grid;
+  grid-template-columns: 108px minmax(160px, .7fr) minmax(0, 1.3fr);
+  align-items: baseline;
+  gap: 16px;
+  border-left: 4px solid rgba(15, 15, 13, 0.16);
+  background: rgba(15, 15, 13, 0.035);
+}
+
+.site-root.is-status-view .status-page .status-timeline-detail.is-clear { border-left-color: var(--home-accent); }
+.site-root.is-status-view .status-page .status-timeline-detail.is-update { border-left-color: #278e72; }
+.site-root.is-status-view .status-page .status-timeline-detail.is-review { border-left-color: #b9a8ef; }
+.site-root.is-status-view .status-page .status-timeline-detail.is-issue { border-left-color: #d85d4a; }
+.site-root.is-status-view .status-page .status-timeline-detail time {
+  color: rgba(15, 15, 13, 0.52);
+  font-size: 11px;
+}
+.site-root.is-status-view .status-page .status-timeline-detail strong { font-size: 13px; }
+.site-root.is-status-view .status-page .status-timeline-detail p {
+  margin: 0;
+  color: rgba(15, 15, 13, 0.6);
+  font-size: 12px;
+  line-height: 1.55;
 }
 
 .site-root.is-status-view .status-page .status-platform-row {
@@ -2736,6 +3054,18 @@
   margin-top: 8px;
 }
 
+.site-root.is-status-view .status-page .status-history-group h3 {
+  margin: 0;
+  padding: 28px 18px 12px;
+  color: rgba(15, 15, 13, 0.62);
+  font: 680 13px/1 var(--font-sans);
+  letter-spacing: .02em;
+}
+
+.site-root.is-status-view .status-page .status-history-group + .status-history-group h3 {
+  border-top: 1px solid rgba(15, 15, 13, 0.14);
+}
+
 .site-root.is-status-view .status-page .status-history-row {
   min-height: 118px;
   padding: 26px 18px;
@@ -2756,6 +3086,7 @@
   .site-root.is-status-view .status-page .status-platform-row {
     min-height: 0;
   }
+
 }
 
 @media (max-width: 620px) {
@@ -2787,6 +3118,29 @@
 
   .site-root.is-status-view .status-page {
     padding: 108px 14px 76px;
+    overflow-x: clip;
+  }
+
+  .site-root.is-status-view .status-page *,
+  .site-root.is-status-view .status-page *::before,
+  .site-root.is-status-view .status-page *::after {
+    min-width: 0;
+    max-width: 100%;
+    box-sizing: border-box;
+  }
+
+  .site-root.is-status-view .status-page .status-shell,
+  .site-root.is-status-view .status-page .status-topbar,
+  .site-root.is-status-view .status-page .status-notice,
+  .site-root.is-status-view .status-page .status-panel {
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    box-sizing: border-box;
+  }
+
+  .site-root.is-status-view .status-page .status-shell {
+    contain: inline-size;
   }
 
   .site-root.is-status-view .status-page .status-topbar {
@@ -2795,7 +3149,70 @@
   }
 
   .site-root.is-status-view .status-page .status-topbar h1 {
-    font-size: clamp(3.8rem, 17vw, 5.7rem);
+    width: 100%;
+    max-width: 100%;
+    font-size: clamp(3rem, 15vw, 4.2rem);
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .site-root.is-status-view .status-page .status-topbar a,
+  .site-root.is-status-view .status-page .status-actions a {
+    box-sizing: border-box;
+  }
+
+  .site-root.is-status-view .status-page .status-notice h2,
+  .site-root.is-status-view .status-page .status-notice p,
+  .site-root.is-status-view .status-page .status-secondary-warning,
+  .site-root.is-status-view .status-page .status-history-row strong,
+  .site-root.is-status-view .status-page .status-history-row p {
+    max-width: 100%;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .site-root.is-status-view .status-page .status-notice h2 {
+    width: 100%;
+    font-size: clamp(2.15rem, 11vw, 3rem);
+  }
+
+  .site-root.is-status-view .status-page .status-panel-head > span {
+    display: none;
+  }
+
+  .site-root.is-status-view .status-page .status-notice-meta {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .site-root.is-status-view .status-page .status-notice-meta span::after {
+    display: none !important;
+  }
+
+  .site-root.is-status-view .status-page .status-timeline {
+    padding: 16px;
+  }
+
+  .site-root.is-status-view .status-page .status-timeline-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .site-root.is-status-view .status-page .status-timeline-years {
+    justify-content: flex-start;
+  }
+
+  .site-root.is-status-view .status-page .status-calendar-months {
+    max-width: none;
+  }
+
+  .site-root.is-status-view .status-page .status-calendar-body {
+    max-width: none;
+  }
+
+  .site-root.is-status-view .status-page .status-timeline-detail {
+    grid-template-columns: 1fr;
+    gap: 7px;
   }
 
   .site-root.is-status-view .status-page .status-notice-body {

--- a/test/messenger-send-stability.test.js
+++ b/test/messenger-send-stability.test.js
@@ -8092,8 +8092,10 @@ function testPopupSupportLinksUseGuidedIssueForms() {
         !headerHtml.includes('>Verification</span>') &&
         !popupHtml.includes('>View</span>') &&
         popupCss.includes('.header-verification') &&
-        popupCss.includes('--status-green: #2ee58d;') &&
-        popupCss.includes('--status-yellow: #f1bd4b;') &&
+        popupCss.includes('--status-green: #27835f;') &&
+        popupCss.includes('--status-yellow: #c98b20;') &&
+        popupCss.includes('.header-verification .status-icon') &&
+        popupCss.includes('box-shadow: none;') &&
         popupCss.includes('.header-verification[data-status="verified"]') &&
         !popupCss.includes('--status-red') &&
         !popupCss.includes('data-status="issue"') &&


### PR DESCRIPTION
## Summary
- rebuild the public status calendar as a dynamic full-year history with clear release, fix, verification, incident, and review states
- add the confirmed Chrome Web Store release timeline and Instagram Hide Story Views incident history
- make status copy user-facing and document/enforce the public status writing rules
- refine homepage feature markers and align the extension popup with the website's cream, black, and lavender theme

## Validation
- npm run build (site)
- npm run test:status
- npm run validate:extension
- npm run test:validator
- git diff --check