### PR TITLE
ci(release): Automate GitHub releases

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,116 @@
+name: Publish GitHub Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version from package.json (for example, 2.0.5)
+        required: true
+        type: string
+      chrome_web_store_approved:
+        description: Confirm this version is approved and live in the Chrome Web Store
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-release-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Validate, package, and publish
+    runs-on: ubuntu-24.04
+
+    env:
+      RELEASE_VERSION: ${{ inputs.version }}
+      STORE_APPROVED: ${{ inputs.chrome_web_store_approved }}
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Check out main
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Validate release request
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error::GitHub Releases must be published from main."
+            exit 1
+          fi
+
+          if [[ "${STORE_APPROVED}" != "true" ]]; then
+            echo "::error::Confirm that this version is approved and live in the Chrome Web Store."
+            exit 1
+          fi
+
+          if [[ ! "${RELEASE_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Version must use X.Y.Z format."
+            exit 1
+          fi
+
+          package_version="$(node -p "require('./package.json').version")"
+          if [[ "${RELEASE_VERSION}" != "${package_version}" ]]; then
+            echo "::error::Requested v${RELEASE_VERSION} does not match package.json v${package_version}."
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "refs/tags/v${RELEASE_VERSION}" >/dev/null 2>&1; then
+            echo "::error::Tag v${RELEASE_VERSION} already exists."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run release validation
+        run: npm run ci
+
+      - name: Build Chrome Web Store package
+        run: npm run package:extension -- --expected-tag "v${RELEASE_VERSION}"
+
+      - name: Verify Chrome Web Store package
+        run: npm run test:package
+
+      - name: Prepare release notes
+        run: node scripts/extract-release-notes.js "${RELEASE_VERSION}" > release-notes.md
+
+      - name: Publish GitHub Release
+        shell: bash
+        run: |
+          zip="ghostify-v${RELEASE_VERSION}-chrome-web-store.zip"
+          checksum="${zip}.sha256"
+
+          gh release create "v${RELEASE_VERSION}" \
+            "${zip}#Chrome Web Store package" \
+            "${checksum}#SHA-256 checksum" \
+            --target "${GITHUB_SHA}" \
+            --title "Ghostify v${RELEASE_VERSION}" \
+            --notes-file release-notes.md \
+            --latest \
+            --fail-on-no-commits
+
+      - name: Summarize release
+        shell: bash
+        run: |
+          {
+            echo "## Ghostify v${RELEASE_VERSION}"
+            echo
+            echo "Published the Git tag and GitHub Release after Chrome Web Store approval."
+            echo
+            echo "- Package: \`ghostify-v${RELEASE_VERSION}-chrome-web-store.zip\`"
+            echo "- Checksum: \`ghostify-v${RELEASE_VERSION}-chrome-web-store.zip.sha256\`"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ grouped by version, with the most recent changes first.
 
 ## [Unreleased]
 
+### Added
+
+- Added a guarded manual GitHub Release workflow that validates the approved
+  Store version, reruns CI, rebuilds the release package, extracts matching
+  changelog notes, creates the version tag, and publishes the ZIP and checksum.
+
 ## [2.0.4] - 2026-07-14
 
 ### Added

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -241,9 +241,15 @@ the generated ZIP. Record `GH-PKG-001` as verified.
 
 - Verify the Store listing shows the approved version.
 - Install or update from the Store and perform a brief popup/load smoke test.
-- Create or update the Git tag `vX.Y.Z`.
-- Create a GitHub Release using the matching `CHANGELOG.md` section.
-- Attach or reference the release ZIP checksum as appropriate.
+- Open **Actions -> Publish GitHub Release -> Run workflow** on `main`.
+- Enter the exact `package.json` version and confirm that it is approved and
+  live in the Chrome Web Store.
+- Let the workflow rerun CI, rebuild and verify the package, extract the
+  matching `CHANGELOG.md` section, create tag `vX.Y.Z`, publish the GitHub
+  Release, and attach the ZIP and SHA-256 checksum.
+- Do not create the tag manually before running the workflow. If the workflow
+  fails, fix the reported release gate instead of bypassing it with a manual
+  release.
 - Close linked issues and thank reporters only when public credit permission exists.
 - Watch new issues for platform regressions after publication.
 

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "index.js",
   "scripts": {
     "build": "node build.js",
-    "test": "npm run build && npm run test:modules && node test/messenger-send-stability.test.js && npm run test:status && npm run test:validator && npm run test:package",
+    "test": "npm run build && npm run test:modules && node test/messenger-send-stability.test.js && npm run test:status && npm run test:release-notes && npm run test:validator && npm run test:package",
     "test:modules": "node test/settings-defaults.test.js && node test/module-registry.test.js && node test/module-flags.test.js",
     "test:validator": "node test/validate-extension-package.test.js",
     "test:status": "node test/prepare-status-update.test.js && node test/daily-verification-git.test.js",
+    "test:release-notes": "node test/extract-release-notes.test.js",
     "test:package": "node test/package-extension.test.js",
     "package:extension": "node scripts/package-extension.js",
     "validate:extension": "node scripts/validate-extension-package.js",

--- a/scripts/extract-release-notes.js
+++ b/scripts/extract-release-notes.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const path = require('path');
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function extractReleaseNotes(changelog, version) {
+    if (!/^\d+\.\d+\.\d+$/.test(version)) {
+        throw new Error('Release version must use X.Y.Z format.');
+    }
+
+    const headingPattern = new RegExp(`^## \\[${escapeRegExp(version)}\\](?: - .+)?$`, 'm');
+    const heading = headingPattern.exec(changelog);
+    if (!heading) throw new Error(`CHANGELOG.md does not contain a release heading for ${version}.`);
+
+    const afterHeading = changelog.slice(heading.index + heading[0].length);
+    const nextHeadingIndex = afterHeading.search(/^## /m);
+    const notes = (nextHeadingIndex === -1 ? afterHeading : afterHeading.slice(0, nextHeadingIndex)).trim();
+    if (!notes) throw new Error(`CHANGELOG.md release ${version} has no notes.`);
+
+    return notes;
+}
+
+function main(argv) {
+    const [version, changelogPath = 'CHANGELOG.md'] = argv;
+    if (!version || argv.length > 2) {
+        throw new Error('Usage: node scripts/extract-release-notes.js <version> [changelog-path]');
+    }
+
+    const changelog = fs.readFileSync(path.resolve(changelogPath), 'utf8');
+    process.stdout.write(`${extractReleaseNotes(changelog, version)}\n`);
+}
+
+if (require.main === module) {
+    try {
+        main(process.argv.slice(2));
+    } catch (error) {
+        console.error(error.message);
+        process.exit(1);
+    }
+}
+
+module.exports = { extractReleaseNotes };

--- a/test/extract-release-notes.test.js
+++ b/test/extract-release-notes.test.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const fs = require('fs');
+
+const { extractReleaseNotes } = require('../scripts/extract-release-notes');
+
+const changelog = fs.readFileSync('CHANGELOG.md', 'utf8');
+const pkg = require('../package.json');
+const notes = extractReleaseNotes(changelog, pkg.version);
+
+assert(notes.includes('### Added'), 'current release notes should include the Added section');
+assert(!notes.includes('## Historical Releases'), 'release notes must stop at the next version heading');
+assert.throws(
+    () => extractReleaseNotes(changelog, '999.999.999'),
+    /does not contain a release heading/
+);
+assert.throws(
+    () => extractReleaseNotes('## [1.2.3]\n\n## [1.2.2]\n\n- Earlier release.', '1.2.3'),
+    /has no notes/
+);
+assert.throws(() => extractReleaseNotes(changelog, 'release-2.0.4'), /must use X.Y.Z format/);
+
+console.log('release-note extraction tests passed');


### PR DESCRIPTION
## Summary

- add a guarded manual workflow for publishing GitHub Releases after Chrome Web Store approval
- require the workflow to run from `main`, match `package.json`, receive explicit Store-approval confirmation, and reject existing tags
- rerun full CI, rebuild and validate the Store package, create the version tag, and attach the ZIP and checksum to the GitHub Release
- extract release notes deterministically from the matching `CHANGELOG.md` section
- document the new post-approval release flow

## Safety model

This workflow intentionally does not run on PR merge. The maintainer must first verify that the exact version is approved and live in the Chrome Web Store, then manually dispatch the workflow from `main`.

No additional repository secrets are required for GitHub Release publication; the workflow uses the scoped `GITHUB_TOKEN` with `contents: write`.

## Validation

- `npm run ci`
- `npm run test:release-notes`
- `npm run validate:extension`
- `actionlint .github/workflows/publish-release.yml`
- `git diff --check`