### PR TITLE
chore(status): Record the v2.0.4 Store release

### DIFF
--- a/site/src/app/statusData.json
+++ b/site/src/app/statusData.json
@@ -2,21 +2,21 @@
   "schemaVersion": 1,
   "product": "Ghostify",
   "productVersion": "2.0.4",
-  "generatedAt": "2026-07-12T09:20:13Z",
+  "generatedAt": "2026-07-16T04:46:21Z",
   "release": {
     "channel": "Chrome Web Store",
     "publishedAt": "2026-02-06",
-    "publishedVersion": "2.0.3",
-    "checkedAt": "2026-07-12T09:20:13Z",
-    "matchesVerificationBuild": false,
+    "publishedVersion": "2.0.4",
+    "checkedAt": "2026-07-16T04:46:21Z",
+    "matchesVerificationBuild": true,
     "storeUrl": "https://chromewebstore.google.com/detail/ghostify-hide-seen-typing/flpnibonbhdmnpgflnbemgghghhblmpm"
   },
   "statusUrl": "https://ghostify-extension.vercel.app/status",
   "historyUrl": "https://ghostify-extension.vercel.app/status/history",
   "summary": {
     "publicStatus": "under_review",
-    "label": "Live status rollout in progress",
-    "message": "Some users may not see live status in the extension popup yet. We’re rolling out an update and will share another update when it’s available."
+    "label": "Live verification pending",
+    "message": "Ghostify 2.0.4 is live on the Chrome Web Store. The current verification pass for the supported controls is pending."
   },
   "policy": {
     "verificationCadence": "Updated when we receive reports, make progress, or complete new checks.",
@@ -165,6 +165,13 @@
     }
   ],
   "history": [
+    {
+      "date": "2026-07-16",
+      "publicStatus": "under_review",
+      "eventType": "release",
+      "title": "Ghostify 2.0.4 published",
+      "summary": "Ghostify 2.0.4 became available on the Chrome Web Store. Live verification of the supported controls is pending."
+    },
     {
       "date": "2026-07-12",
       "publicStatus": "under_review",

--- a/test/messenger-send-stability.test.js
+++ b/test/messenger-send-stability.test.js
@@ -8258,15 +8258,26 @@ function testPopupPublicStatusSummaryUsesWorkingProofDate() {
     vm.runInNewContext(popupSource, context, { filename: 'popup.js' });
 
     const currentStatus = JSON.parse(fs.readFileSync('site/src/app/statusData.json', 'utf8'));
+    const latestHistoryDate = new Date(`${currentStatus.history[0].date}T00:00:00Z`);
+    const compactHistoryDate = new Intl.DateTimeFormat('en-US', {
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'UTC'
+    }).format(latestHistoryDate);
+    const longHistoryDate = new Intl.DateTimeFormat('en-US', {
+        month: 'long',
+        day: 'numeric',
+        timeZone: 'UTC'
+    }).format(latestHistoryDate);
     assert.strictEqual(
         context.summarizePublicStatus(currentStatus),
-        'Jul 12',
+        compactHistoryDate,
         'Popup should show the date from the latest committed status record'
     );
     assert.strictEqual(
         context.getPublicStatusTone(currentStatus),
         'review',
-        'A pending Store build should remain yellow until the status-enabled build is published and verified'
+        'An under-review status should remain yellow until the supported controls are verified'
     );
     assert.strictEqual(
         context.getPublicStatusDescription(currentStatus),
@@ -8274,8 +8285,8 @@ function testPopupPublicStatusSummaryUsesWorkingProofDate() {
         'Popup status tooltip should use the latest public JSON title'
     );
     assert(
-        !context.getPublicStatusDescription(currentStatus).includes('Jul 12') &&
-        !context.getPublicStatusDescription(currentStatus).includes('July 12'),
+        !context.getPublicStatusDescription(currentStatus).includes(compactHistoryDate) &&
+        !context.getPublicStatusDescription(currentStatus).includes(longHistoryDate),
         'Popup status tooltip should not repeat the compact status date'
     );
 

--- a/test/prepare-status-update.test.js
+++ b/test/prepare-status-update.test.js
@@ -7,6 +7,10 @@ const { QA_IDS, isGreenProposalEligible, parseArgs, prepareStatusUpdate } = requ
 
 const repoRoot = path.resolve(__dirname, '..');
 const source = JSON.parse(fs.readFileSync(path.join(repoRoot, 'site', 'src', 'app', 'statusData.json'), 'utf8'));
+const proposalDate = source.release.checkedAt.slice(0, 10);
+const proposalGeneratedAt = new Date(Date.parse(source.release.checkedAt) + 60 * 60 * 1000)
+    .toISOString()
+    .replace('.000Z', 'Z');
 
 function matchingReleaseStatus() {
     const status = structuredClone(source);
@@ -18,33 +22,36 @@ function matchingReleaseStatus() {
 function testVerifiedProposalUpdatesEverySupportedControlWithoutExpiry() {
     const status = prepareStatusUpdate(matchingReleaseStatus(), {
         mode: 'verified',
-        date: '2026-07-12',
-        generatedAt: '2026-07-12T10:15:00Z'
+        date: proposalDate,
+        generatedAt: proposalGeneratedAt
     });
 
     assert.strictEqual(status.summary.publicStatus, 'maintainer_verified');
-    assert.strictEqual(status.history[0].date, '2026-07-12');
+    assert.strictEqual(status.history[0].date, proposalDate);
     assert.strictEqual(status.history[0].publicStatus, 'maintainer_verified');
     assert.strictEqual(status.entries.length, Object.keys(QA_IDS).length);
 
     for (const entry of status.entries) {
         assert.strictEqual(entry.publicStatus, 'maintainer_verified');
         assert.strictEqual(entry.localEvidenceStatus, 'verified');
-        assert.strictEqual(entry.verifiedAt, '2026-07-12T00:00:00Z');
+        assert.strictEqual(entry.verifiedAt, `${proposalDate}T00:00:00Z`);
         assert(!Object.hasOwn(entry, 'expiresAt'));
         assert(entry.reviewRecord.includes(QA_IDS[entry.id]));
     }
 }
 
 function testVerifiedProposalRejectsStoreBuildMismatch() {
+    const mismatchingStatus = structuredClone(source);
+    mismatchingStatus.release.publishedVersion = '2.0.3';
+    mismatchingStatus.release.matchesVerificationBuild = false;
     assert.throws(
-        () => prepareStatusUpdate(source, {
+        () => prepareStatusUpdate(mismatchingStatus, {
             mode: 'verified',
-            date: '2026-07-12',
-            generatedAt: '2026-07-12T10:15:00Z'
+            date: proposalDate,
+            generatedAt: proposalGeneratedAt
         }),
         error => error.message.includes(
-            `Store v${source.release.publishedVersion} does not match build v${source.productVersion}`
+            `Store v${mismatchingStatus.release.publishedVersion} does not match build v${mismatchingStatus.productVersion}`
         )
     );
 }
@@ -52,8 +59,8 @@ function testVerifiedProposalRejectsStoreBuildMismatch() {
 function testReportedProposalTurnsSelectedControlAndOverallStatusYellow() {
     const status = prepareStatusUpdate(source, {
         mode: 'reported',
-        date: '2026-07-12',
-        generatedAt: '2026-07-12T10:15:00Z',
+        date: proposalDate,
+        generatedAt: proposalGeneratedAt,
         featureIds: ['messenger-hide-typing'],
         note: 'Users report that Messenger Hide Typing may not be working.'
     });
@@ -70,14 +77,16 @@ function testReportedProposalTurnsSelectedControlAndOverallStatusYellow() {
 function testInProgressProposalStaysYellowAndPreservesHistory() {
     const reported = prepareStatusUpdate(source, {
         mode: 'reported',
-        date: '2026-07-12',
-        generatedAt: '2026-07-12T10:15:00Z',
+        date: proposalDate,
+        generatedAt: proposalGeneratedAt,
         featureIds: ['messenger-hide-typing']
     });
     const working = prepareStatusUpdate(reported, {
         mode: 'in-progress',
-        date: '2026-07-12',
-        generatedAt: '2026-07-12T11:00:00Z',
+        date: proposalDate,
+        generatedAt: new Date(Date.parse(proposalGeneratedAt) + 60 * 60 * 1000)
+            .toISOString()
+            .replace('.000Z', 'Z'),
         featureIds: ['messenger-hide-typing'],
         note: 'A fix for Messenger Hide Typing is in progress.'
     });
@@ -91,8 +100,8 @@ function testInProgressProposalStaysYellowAndPreservesHistory() {
 function testKnownIssueProposalUpdatesOnlySelectedControls() {
     const status = prepareStatusUpdate(source, {
         mode: 'known-issue',
-        date: '2026-07-12',
-        generatedAt: '2026-07-12T10:15:00Z',
+        date: proposalDate,
+        generatedAt: proposalGeneratedAt,
         featureIds: ['facebook-hide-seen'],
         issueUrl: 'https://github.com/Hendrizzzz/Ghostify/issues/123',
         note: 'Facebook Hide Seen has a confirmed issue.'
@@ -108,8 +117,8 @@ function testYellowProposalRejectsUnknownControl() {
     assert.throws(
         () => prepareStatusUpdate(source, {
             mode: 'reported',
-            date: '2026-07-12',
-            generatedAt: '2026-07-12T10:15:00Z',
+            date: proposalDate,
+            generatedAt: proposalGeneratedAt,
             featureIds: ['unknown-feature']
         }),
         /Unknown feature id/
@@ -132,14 +141,17 @@ function testStatusInputsRejectImpossibleDatesAndDuplicateFeatures() {
     }), /Invalid UTC date/);
     assert.throws(() => prepareStatusUpdate(source, {
         mode: 'reported',
-        date: '2026-07-12',
-        generatedAt: '2026-07-12T10:15:00Z',
+        date: proposalDate,
+        generatedAt: proposalGeneratedAt,
         featureIds: ['messenger-hide-typing', 'messenger-hide-typing']
     }), /must not contain duplicates/);
 }
 
 function testGreenEligibilityRequiresMatchingBuildAndProtectsYellowSchedule() {
-    assert.deepStrictEqual(isGreenProposalEligible(source, { scheduled: true }), {
+    const mismatchingYellow = structuredClone(source);
+    mismatchingYellow.release.publishedVersion = '2.0.3';
+    mismatchingYellow.release.matchesVerificationBuild = false;
+    assert.deepStrictEqual(isGreenProposalEligible(mismatchingYellow, { scheduled: true }), {
         latestStatusIsGreen: false,
         storeBuildMatches: false,
         ready: false

--- a/test/validate-extension-package.test.js
+++ b/test/validate-extension-package.test.js
@@ -74,6 +74,16 @@ function writeStatusJsonPair(fixtureRoot, statusJson) {
     writeStatusJson(path.join(fixtureRoot, 'site', 'src', 'app', 'statusData.json'), statusJson);
 }
 
+function proposalTiming(statusJson, hoursAfterStoreCheck = 1) {
+    const generatedAt = new Date(Date.parse(statusJson.release.checkedAt) + hoursAfterStoreCheck * 60 * 60 * 1000)
+        .toISOString()
+        .replace('.000Z', 'Z');
+    return {
+        date: generatedAt.slice(0, 10),
+        generatedAt
+    };
+}
+
 function withFixture(testFn) {
     const fixtureRoot = copyFixture();
     try {
@@ -106,8 +116,7 @@ withFixture(fixtureRoot => {
     statusJson.release.matchesVerificationBuild = true;
     const proposal = prepareStatusUpdate(statusJson, {
         mode: 'verified',
-        date: '2026-07-12',
-        generatedAt: '2026-07-12T10:15:00Z'
+        ...proposalTiming(statusJson)
     });
     writeStatusJsonPair(fixtureRoot, proposal);
 
@@ -117,6 +126,8 @@ withFixture(fixtureRoot => {
 
 withFixture(fixtureRoot => {
     const { statusJson } = readStatusJson(fixtureRoot);
+    statusJson.release.publishedVersion = '2.0.3';
+    statusJson.release.matchesVerificationBuild = false;
     statusJson.summary.publicStatus = 'maintainer_verified';
     statusJson.history[0].publicStatus = 'maintainer_verified';
     writeStatusJsonPair(fixtureRoot, statusJson);
@@ -127,6 +138,8 @@ withFixture(fixtureRoot => {
 
 withFixture(fixtureRoot => {
     const { statusJson } = readStatusJson(fixtureRoot);
+    statusJson.release.publishedVersion = '2.0.3';
+    statusJson.release.matchesVerificationBuild = false;
     statusJson.entries[0].publicStatus = 'maintainer_verified';
     writeStatusJsonPair(fixtureRoot, statusJson);
     const result = runValidator(fixtureRoot);
@@ -138,8 +151,7 @@ withFixture(fixtureRoot => {
     const { statusJson } = readStatusJson(fixtureRoot);
     const proposal = prepareStatusUpdate(statusJson, {
         mode: 'known-issue',
-        date: '2026-07-12',
-        generatedAt: '2026-07-12T10:30:00Z',
+        ...proposalTiming(statusJson),
         featureIds: ['messenger-hide-typing'],
         note: 'Messenger Hide Typing has a confirmed issue.'
     });
@@ -151,7 +163,9 @@ withFixture(fixtureRoot => {
 
 withFixture(fixtureRoot => {
     const { statusJson } = readStatusJson(fixtureRoot);
-    statusJson.generatedAt = '2026-07-09T20:00:00Z';
+    statusJson.generatedAt = new Date(Date.parse(statusJson.release.checkedAt) - 60 * 60 * 1000)
+        .toISOString()
+        .replace('.000Z', 'Z');
     writeStatusJsonPair(fixtureRoot, statusJson);
 
     const result = runValidator(fixtureRoot);


### PR DESCRIPTION
﻿## Summary

- record Ghostify 2.0.4 as the live Chrome Web Store build
- keep the supported controls under review until the maintainer completes live verification
- add the v2.0.4 publication to public status history
- make status tests derive their dates and Store-mismatch fixtures from the canonical data so future status updates can pass CI

## Validation

- `npm run ci`
- `npm run build --prefix site`

## Publication behavior

Merging this PR publishes the updated release metadata through the website status feed after deployment. It does not mark any supported control verified. Run the `Daily verification PR` workflow in `verified` mode after this PR is merged, complete the live smoke checklist, and merge that separate approval PR only if all checks pass.
