### PR TITLE
feat(site): Prioritize status severity in the calendar

### DIFF
--- a/site/src/app/components/StatusPage.tsx
+++ b/site/src/app/components/StatusPage.tsx
@@ -218,7 +218,13 @@ function buildTimelineDays(year: number, today: Date): TimelineDay[] {
   const yearStart = new Date(Date.UTC(year, 0, 1));
   const calendarStart = new Date(yearStart);
   calendarStart.setUTCDate(calendarStart.getUTCDate() - calendarStart.getUTCDay());
-  const events = [...STATUS_DATA.history].sort((left, right) => Date.parse(left.date) - Date.parse(right.date));
+  const events = STATUS_DATA.history
+    .map((event, sourceIndex) => ({ event, sourceIndex }))
+    .sort((left, right) => {
+      const dateOrder = Date.parse(left.event.date) - Date.parse(right.event.date);
+      return dateOrder || right.sourceIndex - left.sourceIndex;
+    })
+    .map(({ event }) => event);
   const eventByDate = new Map(events.map((event) => [event.date, event]));
   const cellCount = 54 * 7;
 

--- a/site/src/app/components/StatusPage.tsx
+++ b/site/src/app/components/StatusPage.tsx
@@ -186,13 +186,15 @@ function CurrentNotice() {
   );
 }
 
-type TimelineTone = 'clear' | 'update' | 'issue' | 'review' | 'quiet' | 'outside' | 'upcoming';
+type TimelineTone = 'clear' | 'issue' | 'review' | 'quiet' | 'outside' | 'upcoming';
 
 type TimelineDay = {
   date: string;
   tone: TimelineTone;
   label: string;
   detail: string;
+  hasUpdate: boolean;
+  updateLabel: string | null;
   column: number;
   row: number;
 };
@@ -208,9 +210,24 @@ function toneForStatus(status: PublicVerificationStatus): TimelineTone {
   return 'quiet';
 }
 
-function toneForEvent(event: (typeof STATUS_DATA.history)[number]): TimelineTone {
-  if (event.eventType === 'release' || event.eventType === 'fix') return 'update';
-  return toneForStatus(event.publicStatus);
+function isProductUpdate(event: (typeof STATUS_DATA.history)[number]) {
+  return event.eventType === 'release' || event.eventType === 'fix';
+}
+
+function statusPriority(event: (typeof STATUS_DATA.history)[number]) {
+  const tone = toneForStatus(event.publicStatus);
+  if (tone === 'issue') return 3;
+  if (tone === 'review') return 2;
+  if (tone === 'clear') return 1;
+  return 0;
+}
+
+function primaryEventForDay(events: (typeof STATUS_DATA.history)[number][]) {
+  const explicitStatusEvents = events.filter((event) => !isProductUpdate(event));
+  const candidates = explicitStatusEvents.length ? explicitStatusEvents : events;
+  return candidates.reduce((selected, event) => (
+    statusPriority(event) > statusPriority(selected) ? event : selected
+  ));
 }
 
 function buildTimelineDays(year: number, today: Date): TimelineDay[] {
@@ -225,7 +242,10 @@ function buildTimelineDays(year: number, today: Date): TimelineDay[] {
       return dateOrder || right.sourceIndex - left.sourceIndex;
     })
     .map(({ event }) => event);
-  const eventByDate = new Map(events.map((event) => [event.date, event]));
+  const eventsByDate = new Map<string, (typeof STATUS_DATA.history)[number][]>();
+  STATUS_DATA.history.forEach((event) => {
+    eventsByDate.set(event.date, [...(eventsByDate.get(event.date) ?? []), event]);
+  });
   const cellCount = 54 * 7;
 
   return Array.from({ length: cellCount }, (_, index) => {
@@ -234,7 +254,9 @@ function buildTimelineDays(year: number, today: Date): TimelineDay[] {
     const date = toDateKey(current);
     const time = current.getTime();
     const inYear = current.getUTCFullYear() === year;
-    const event = eventByDate.get(date);
+    const dayEvents = eventsByDate.get(date) ?? [];
+    const event = dayEvents.length ? primaryEventForDay(dayEvents) : null;
+    const productUpdate = dayEvents.find(isProductUpdate) ?? null;
     const latestEvent = events.filter((item) => Date.parse(item.date) <= time).at(-1);
     let tone: TimelineTone = 'quiet';
     let label = 'No status update recorded';
@@ -259,7 +281,7 @@ function buildTimelineDays(year: number, today: Date): TimelineDay[] {
     }
 
     if (event) {
-      tone = toneForEvent(event);
+      tone = toneForStatus(event.publicStatus);
       label = event.title;
       detail = event.summary;
     }
@@ -269,6 +291,8 @@ function buildTimelineDays(year: number, today: Date): TimelineDay[] {
       tone,
       label,
       detail,
+      hasUpdate: Boolean(productUpdate),
+      updateLabel: productUpdate && productUpdate !== event ? productUpdate.title : null,
       column: Math.floor(index / 7) + 1,
       row: (index % 7) + 1,
     };
@@ -290,11 +314,14 @@ function VerificationTimeline() {
     ? days.find((day) => day.date === selectedDate && day.date.startsWith(`${selectedYear}-`)) ?? null
     : null;
   const latestUpdate = STATUS_DATA.history[0];
-  const detail = selected ?? {
+  const latestDay = days.find((day) => day.date === latestUpdate.date) ?? null;
+  const detail = selected ?? latestDay ?? {
     date: latestUpdate.date,
-    tone: toneForEvent(latestUpdate),
+    tone: toneForStatus(latestUpdate.publicStatus),
     label: latestUpdate.title,
     detail: latestUpdate.summary,
+    hasUpdate: isProductUpdate(latestUpdate),
+    updateLabel: null,
   };
   const months = useMemo(() => Array.from({ length: 12 }, (_, month) => {
     const first = new Date(Date.UTC(selectedYear, month, 1));
@@ -329,7 +356,7 @@ function VerificationTimeline() {
       </div>
       <div className="status-timeline-legend" aria-hidden="true">
         <span className="is-clear">No known issue</span>
-        <span className="is-update">Product update</span>
+        <span className="is-update">Product update marker</span>
         <span className="is-review">Under review</span>
         <span className="is-issue">Known issue</span>
         <span className="is-quiet">No update</span>
@@ -344,15 +371,16 @@ function VerificationTimeline() {
             {days.map((day) => (
               <button
                 type="button"
-                className={`status-calendar-day is-${day.tone}${selectedDate === day.date ? ' is-selected' : ''}${day.column <= 3 ? ' is-tooltip-left' : ''}${day.column >= 52 ? ' is-tooltip-right' : ''}`}
+                className={`status-calendar-day is-${day.tone}${day.hasUpdate ? ' has-update' : ''}${selectedDate === day.date ? ' is-selected' : ''}${day.column <= 3 ? ' is-tooltip-left' : ''}${day.column >= 52 ? ' is-tooltip-right' : ''}`}
                 style={{ gridColumn: day.column, gridRow: day.row }}
-                aria-label={`${formatStatusDate(day.date)}: ${day.label}`}
+                aria-label={`${formatStatusDate(day.date)}: ${day.label}${day.updateLabel ? `. Product update: ${day.updateLabel}` : ''}`}
                 aria-pressed={selectedDate === day.date}
                 onClick={() => setSelectedDate((current) => current === day.date ? null : day.date)}
                 key={day.date}
               >
                 <span className="status-calendar-tooltip" role="tooltip">
                   <b>{formatStatusDate(day.date)}</b>{day.label}
+                  {day.updateLabel && <em>Product update · {day.updateLabel}</em>}
                 </span>
               </button>
             ))}
@@ -361,7 +389,10 @@ function VerificationTimeline() {
       </div>
       <div className={`status-timeline-detail is-${detail.tone}`} aria-live="polite">
         <time>{formatStatusDate(detail.date)}</time>
-        <strong>{detail.label}</strong>
+        <div className="status-timeline-detail-title">
+          <strong>{detail.label}</strong>
+          {detail.updateLabel && <span>Product update · {detail.updateLabel}</span>}
+        </div>
         <p>{detail.detail}</p>
       </div>
     </div>

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -3641,8 +3641,11 @@
 
 .site-root.is-status-view .status-page .status-timeline-legend .is-clear::before,
 .site-root.is-status-view .status-page .status-calendar-day.is-clear { background: var(--home-accent); }
-.site-root.is-status-view .status-page .status-timeline-legend .is-update::before,
-.site-root.is-status-view .status-page .status-calendar-day.is-update { background: #278e72; }
+.site-root.is-status-view .status-page .status-timeline-legend .is-update::before {
+  box-sizing: border-box;
+  border: 2px solid #278e72;
+  background: transparent;
+}
 .site-root.is-status-view .status-page .status-timeline-legend .is-review::before,
 .site-root.is-status-view .status-page .status-calendar-day.is-review { background: #b9a8ef; }
 .site-root.is-status-view .status-page .status-timeline-legend .is-issue::before,
@@ -3720,6 +3723,15 @@
   position: relative;
 }
 
+.site-root.is-status-view .status-page .status-calendar-day.has-update::after {
+  position: absolute;
+  inset: -2px;
+  border: 1px solid #278e72;
+  border-radius: 5px;
+  content: '';
+  pointer-events: none;
+}
+
 .site-root.is-status-view .status-page .status-calendar-day:hover {
   z-index: 2;
   filter: brightness(0.88);
@@ -3774,6 +3786,16 @@
   font-weight: 650;
 }
 
+.site-root.is-status-view .status-page .status-calendar-tooltip em {
+  margin-top: 2px;
+  padding-top: 5px;
+  border-top: 1px solid rgba(244, 239, 227, 0.18);
+  color: rgba(244, 239, 227, 0.72);
+  font-size: 9px;
+  font-style: normal;
+  font-weight: 550;
+}
+
 .site-root.is-status-view .status-page .status-calendar-day:hover .status-calendar-tooltip,
 .site-root.is-status-view .status-page .status-calendar-day:focus-visible .status-calendar-tooltip {
   opacity: 1;
@@ -3803,14 +3825,23 @@
 }
 
 .site-root.is-status-view .status-page .status-timeline-detail.is-clear { border-left-color: var(--home-accent); }
-.site-root.is-status-view .status-page .status-timeline-detail.is-update { border-left-color: #278e72; }
 .site-root.is-status-view .status-page .status-timeline-detail.is-review { border-left-color: #b9a8ef; }
 .site-root.is-status-view .status-page .status-timeline-detail.is-issue { border-left-color: #d85d4a; }
 .site-root.is-status-view .status-page .status-timeline-detail time {
   color: rgba(15, 15, 13, 0.52);
   font-size: 11px;
 }
-.site-root.is-status-view .status-page .status-timeline-detail strong { font-size: 13px; }
+.site-root.is-status-view .status-page .status-timeline-detail-title {
+  display: grid;
+  gap: 4px;
+}
+.site-root.is-status-view .status-page .status-timeline-detail-title strong { font-size: 13px; }
+.site-root.is-status-view .status-page .status-timeline-detail-title span {
+  color: #27785f;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: .02em;
+}
 .site-root.is-status-view .status-page .status-timeline-detail p {
   margin: 0;
   color: rgba(15, 15, 13, 0.6);

--- a/test/messenger-send-stability.test.js
+++ b/test/messenger-send-stability.test.js
@@ -8269,6 +8269,10 @@ function testPopupPublicStatusSummaryUsesWorkingProofDate() {
         day: 'numeric',
         timeZone: 'UTC'
     }).format(latestHistoryDate);
+    const expectedTone = currentStatus.release.matchesVerificationBuild &&
+        ['maintainer_verified', 'community_verified_reviewed'].includes(currentStatus.history[0].publicStatus)
+        ? 'verified'
+        : 'review';
     assert.strictEqual(
         context.summarizePublicStatus(currentStatus),
         compactHistoryDate,
@@ -8276,8 +8280,8 @@ function testPopupPublicStatusSummaryUsesWorkingProofDate() {
     );
     assert.strictEqual(
         context.getPublicStatusTone(currentStatus),
-        'review',
-        'An under-review status should remain yellow until the supported controls are verified'
+        expectedTone,
+        'Popup tone should follow the latest status record for the published Store build'
     );
     assert.strictEqual(
         context.getPublicStatusDescription(currentStatus),


### PR DESCRIPTION
﻿## Summary

- make same-day calendar cells severity-first: known issue, under review/in progress, then verified
- keep product publication and fix events as a secondary outlined marker instead of allowing them to hide health status
- preserve every public history record while showing the highest-priority same-day status in the cell, tooltip, and detail panel
- keep equal-priority records newest-first
- make popup status tests follow the canonical status tone generated by the verification workflow

## Same-day behavior

- issue + release = issue cell with a product-update marker
- review + release = review cell with a product-update marker
- verification + release = verified cell with a product-update marker
- multiple equal-severity updates = latest record wins

## Validation

- `npm run ci`
- `npm run build --prefix site`
- desktop and 390px browser QA with a temporary same-day v2.0.4 publication + verification fixture
- browser console: no errors or warnings

The public history remains complete. The calendar communicates operational health first and publication second.
