### PR TITLE
test(status): Isolate scheduled verification eligibility

### DIFF
--- a/test/prepare-status-update.test.js
+++ b/test/prepare-status-update.test.js
@@ -149,6 +149,7 @@ function testStatusInputsRejectImpossibleDatesAndDuplicateFeatures() {
 
 function testGreenEligibilityRequiresMatchingBuildAndProtectsYellowSchedule() {
     const mismatchingYellow = structuredClone(source);
+    mismatchingYellow.summary.publicStatus = 'under_review';
     mismatchingYellow.release.publishedVersion = '2.0.3';
     mismatchingYellow.release.matchesVerificationBuild = false;
     assert.deepStrictEqual(isGreenProposalEligible(mismatchingYellow, { scheduled: true }), {


### PR DESCRIPTION
## Summary
- make the scheduled-verification eligibility fixture explicitly under review
- keep the test independent from the generated verified status written earlier in the workflow

## Validation
- npm run test:status
- npm run ci

Merging this restores the verified-status proposal workflow. It does not publish a status update by itself.