### PR TITLE
feat(site): Refine trust and status presentation

### DIFF
--- a/site/src/app/components/HomePage.tsx
+++ b/site/src/app/components/HomePage.tsx
@@ -80,7 +80,7 @@ const PLATFORMS: Array<{
   { platform: 'facebook', name: 'Facebook', url: 'facebook.com', qualifier: 'Shared settings with Messenger' },
 ];
 
-const AI_PROMPT = 'Review Ghostify independently using https://ghostify-extension.vercel.app and its linked public source. Explain what it does, who it is for, how its permissions and privacy model work, and any current limitations or verification caveats someone should know before installing.';
+const AI_PROMPT = 'Is the Ghostify Chrome extension by Hendrizzzz right for me? Use only its official Chrome Web Store listing and GitHub documentation. Explain in plain English what it helps me do, what stays on my device, why it needs access to Instagram, Facebook, and Messenger, and its real limitations. Ignore unrelated Ghostify products and third-party directories. Keep it short.';
 
 const AI_LINKS = [
   { name: 'ChatGPT', href: `https://chatgpt.com/?q=${encodeURIComponent(AI_PROMPT)}` },
@@ -620,7 +620,7 @@ function EvidenceSection() {
       <div className="evidence-card" data-reveal>
         <div className="evidence-lead">
           <h2>Don&apos;t take<br />our word for it.</h2>
-          <p>Open a ready-made prompt asking it to review Ghostify&apos;s public website, source, privacy model, and current limitations.</p>
+          <p>Ask an independent model what Ghostify does, what stays on your device, and whether it fits the way you browse.</p>
         </div>
         <div className="evidence-actions">
           {AI_LINKS.map((item) => (
@@ -631,9 +631,9 @@ function EvidenceSection() {
           ))}
         </div>
         <div className="evidence-proof" aria-label="Ghostify public evidence">
-          <span><Code2 size={20} aria-hidden="true" /><strong>Public source</strong></span>
-          <span><LockKeyhole size={20} aria-hidden="true" /><strong>Permission boundary</strong></span>
-          <span><ShieldCheck size={20} aria-hidden="true" /><strong>Dated verification</strong></span>
+          <span><Code2 size={20} aria-hidden="true" /><strong>Open source</strong></span>
+          <span><LockKeyhole size={20} aria-hidden="true" /><strong>Clear permissions</strong></span>
+          <span><ShieldCheck size={20} aria-hidden="true" /><strong>Latest checks</strong></span>
         </div>
         <span className="evidence-ghost" aria-hidden="true"><GhostMark size={170} /></span>
       </div>
@@ -897,8 +897,8 @@ export function HomePage() {
       </section>
 
       <FootprintSection />
-      <FactMarquee />
       <InstallRhythm />
+      <FactMarquee />
 
       <section className="faq-flat" data-scroll-scene>
         <header data-reveal>

--- a/site/src/app/components/StatusPage.tsx
+++ b/site/src/app/components/StatusPage.tsx
@@ -46,7 +46,7 @@ const STATUS_META: Record<
   community_verified_reviewed: { short: 'Working', tone: 'ok' },
   under_review: { short: 'Under review', tone: 'warn' },
   work_in_progress: { short: 'Working on it', tone: 'warn' },
-  known_issue: { short: 'Known issue', tone: 'warn' },
+  known_issue: { short: 'Known issue', tone: 'bad' },
   public_status_unavailable: { short: 'Unavailable', tone: 'muted' },
 };
 
@@ -176,9 +176,7 @@ function CurrentNotice() {
           </a>
         )}
         <div className="status-notice-meta">
-          <span>{STATUS_LABELS[overallStatus]}</span>
-          <span>Generated {formatStatusDate(STATUS_DATA.generatedAt)}</span>
-          <span>Store checked {formatStatusDate(STATUS_DATA.release.checkedAt)}</span>
+          <span>{STATUS_LABELS[overallStatus]} {formatStatusDate(STATUS_DATA.generatedAt)}</span>
           <span>{STATUS_DATA.policy.verificationCadence}</span>
         </div>
       </div>
@@ -356,7 +354,7 @@ function VerificationTimeline() {
       </div>
       <div className="status-timeline-legend" aria-hidden="true">
         <span className="is-clear">No known issue</span>
-        <span className="is-update">Product update marker</span>
+        <span className="is-update">Product update</span>
         <span className="is-review">Under review</span>
         <span className="is-issue">Known issue</span>
         <span className="is-quiet">No update</span>

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -1091,7 +1091,7 @@
   content: 'held';
   position: absolute;
   left: -18px;
-  bottom: -44px;
+  bottom: -20px;
   color: rgba(15, 15, 13, 0.045);
   font-family: var(--font-editorial);
   font-size: clamp(10rem, 19vw, 20rem);
@@ -1666,7 +1666,7 @@
   content: 'local';
   position: absolute;
   right: -10px;
-  bottom: -54px;
+  bottom: -26px;
   color: rgba(15, 15, 13, 0.04);
   font-family: var(--font-editorial);
   font-size: clamp(10rem, 22vw, 24rem);
@@ -1761,9 +1761,7 @@
   grid-template-columns: minmax(300px, 0.82fr) minmax(560px, 1.18fr);
   align-items: center;
   gap: clamp(56px, 9vw, 140px);
-  background:
-    radial-gradient(circle at 84% 20%, rgba(136, 115, 207, 0.14), transparent 25%),
-    linear-gradient(135deg, var(--home-cream), var(--home-grey));
+  background: var(--home-grey);
 }
 
 .install-rhythm::before {
@@ -2241,7 +2239,7 @@
   content: 'quiet';
   position: absolute;
   right: -20px;
-  bottom: -46px;
+  bottom: -22px;
   color: rgba(15, 15, 13, 0.055);
   font-family: var(--font-editorial);
   font-size: clamp(9rem, 18vw, 19rem);
@@ -3185,7 +3183,12 @@
   }
 
   .evidence-lead h2 { font-size: clamp(2.3rem, 9.6vw, 2.75rem); }
-  .evidence-actions { width: 100%; display: grid; }
+  .evidence-actions {
+    width: 100%;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    justify-content: stretch;
+  }
   .evidence-actions a { width: 100%; }
   .evidence-proof { grid-template-columns: 1fr; }
   .evidence-proof > span { min-height: 58px; border-right: 0; border-bottom: 1px solid rgba(15, 15, 13, 0.16); }
@@ -3416,6 +3419,10 @@
   --status-red-text: #8873cf;
   --status-surface: #e9e4d7;
   --status-surface-soft: rgba(243, 238, 226, 0.72);
+  --status-update: #278e72;
+  --status-update-soft: rgba(39, 142, 114, 0.2);
+  --status-issue: #c95d3e;
+  --status-issue-soft: rgba(201, 93, 62, 0.1);
   --status-line: rgba(15, 15, 13, 0.14);
   --status-line-strong: rgba(15, 15, 13, 0.22);
   --status-text: rgba(15, 15, 13, 0.84);
@@ -3682,9 +3689,8 @@
 .site-root.is-status-view .status-page .status-timeline-legend .is-clear::before,
 .site-root.is-status-view .status-page .status-calendar-day.is-clear { background: var(--home-accent); }
 .site-root.is-status-view .status-page .status-timeline-legend .is-update::before {
-  box-sizing: border-box;
-  border: 2px solid #278e72;
-  background: transparent;
+  border-radius: 3px;
+  background: var(--status-update);
 }
 .site-root.is-status-view .status-page .status-timeline-legend .is-review::before,
 .site-root.is-status-view .status-page .status-calendar-day.is-review { background: #b9a8ef; }
@@ -3765,13 +3771,8 @@
   position: relative;
 }
 
-.site-root.is-status-view .status-page .status-calendar-day.has-update::after {
-  position: absolute;
-  inset: -2px;
-  border: 1px solid #278e72;
-  border-radius: 5px;
-  content: '';
-  pointer-events: none;
+.site-root.is-status-view .status-page .status-calendar-day.has-update {
+  background: var(--status-update);
 }
 
 .site-root.is-status-view .status-page .status-calendar-day:hover {
@@ -3924,7 +3925,11 @@
 
 .site-root.is-status-view .status-page .status-warn { color: var(--home-accent); }
 .site-root.is-status-view .status-page .status-ok { color: #287a50; }
-.site-root.is-status-view .status-page .status-bad { color: #9e3f32; }
+.site-root.is-status-view .status-page .status-pill.status-bad {
+  border-color: rgba(201, 93, 62, 0.28);
+  color: var(--status-issue);
+  background: var(--status-issue-soft);
+}
 
 .site-root.is-status-view .status-page .status-rail-segment {
   height: 10px;
@@ -3934,7 +3939,7 @@
 
 .site-root.is-status-view .status-page .status-rail-ok { background: #287a50; }
 .site-root.is-status-view .status-page .status-rail-warn { background: var(--home-accent); }
-.site-root.is-status-view .status-page .status-rail-bad { background: #9e3f32; }
+.site-root.is-status-view .status-page .status-rail-bad { background: var(--status-issue); }
 .site-root.is-status-view .status-page .status-rail-muted { background: rgba(15, 15, 13, 0.1); }
 
 .site-root.is-status-view .status-page .status-feature-list {


### PR DESCRIPTION
## Summary

- refines the independent-review prompt and makes its proof labels easier to understand
- improves the landing-page section flow, background continuity, decorative typography placement, and mobile evidence actions
- simplifies status metadata and gives product updates and known issues clearer, consistent semantic colors

## Why

The final website pass exposed a few areas where trust copy, section transitions, decorative crops, and status markers were either overly technical, visually inconsistent, or harder to scan than intended.

## Validation

- `cd site && npm run build`
- desktop and mobile browser checks
- no horizontal overflow or relevant console errors
- verified green, purple, and orange calendar markers use flat solid fills with no gradients or shadows