### PR TITLE
ci(security): Harden repository workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Run actionlint
-        run: docker run --rm -v "${{ github.workspace }}:/repo" --workdir /repo rhysd/actionlint:1.7.12 -color
+        run: docker run --rm -v "${{ github.workspace }}:/repo" --workdir /repo rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color
 
   extension:
     name: Extension checks
@@ -39,12 +39,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24.x
           cache: npm
@@ -62,13 +62,13 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@v2
+        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITLEAKS_CONFIG: .gitleaks.toml
@@ -79,12 +79,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24.x
           cache: npm
@@ -111,12 +111,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24.x
           cache: npm
@@ -134,7 +134,8 @@ jobs:
           fi
 
       - name: Upload release package
-        uses: actions/upload-artifact@v4
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: chrome-web-store-package
           path: |

--- a/.github/workflows/daily-verification.yml
+++ b/.github/workflows/daily-verification.yml
@@ -47,17 +47,17 @@ jobs:
       NOTE: ${{ github.event.inputs.note || '' }}
       EVENT_NAME: ${{ github.event_name }}
       DAILY_BRANCH: chore/status-daily-verification
-      GH_TOKEN: ${{ github.token }}
 
     steps:
       - name: Check out main
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: main
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24.x
           cache: npm
@@ -109,6 +109,8 @@ jobs:
       - name: Close stale daily PR while live status is yellow
         if: github.event_name == 'schedule' && steps.eligible.outputs.ready != 'true'
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           pr_number="$(gh pr list --state open --head "$DAILY_BRANCH" --json number --jq '.[0].number // empty')"
           if [[ -n "$pr_number" ]]; then
@@ -155,7 +157,9 @@ jobs:
           BRANCH: ${{ steps.proposal.outputs.branch }}
           TITLE: ${{ steps.proposal.outputs.title }}
           BASE_SHA: ${{ steps.proposal.outputs.base_sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
+          gh auth setup-git
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin main
@@ -180,6 +184,7 @@ jobs:
           BRANCH: ${{ steps.proposal.outputs.branch }}
           TITLE: ${{ steps.proposal.outputs.title }}
           TODAY: ${{ steps.proposal.outputs.today }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [[ "$MODE" == "verified" ]]; then
             cat > "$RUNNER_TEMP/pr-body.md" <<EOF

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -28,17 +28,16 @@ jobs:
     env:
       RELEASE_VERSION: ${{ inputs.version }}
       STORE_APPROVED: ${{ inputs.chrome_web_store_approved }}
-      GH_TOKEN: ${{ github.token }}
 
     steps:
       - name: Check out main
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         with:
           node-version: 24.x
           cache: npm
@@ -90,6 +89,8 @@ jobs:
 
       - name: Publish GitHub Release
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           zip="ghostify-v${RELEASE_VERSION}-chrome-web-store.zip"
           checksum="${zip}.sha256"


### PR DESCRIPTION
## Summary

This change reduces repository supply-chain risk without changing Ghostify's extension runtime or website behavior. Workflow dependencies are immutable, write-capable credentials are unavailable during dependency installation and validation, and pull-request builds no longer publish official-looking extension packages.

## What changed

- Pin GitHub Actions to full commit SHAs and actionlint to an immutable container digest.
- Scope `GH_TOKEN` to the exact daily-status push/PR and release-publication steps that need it.
- Disable persisted checkout credentials in the write-enabled daily workflow.
- Continue building PR packages for validation, but upload installable artifacts only for trusted non-PR events.

Repository settings were also updated separately to enable secret scanning, push protection, and Dependabot security updates; require the `Secret scan` check; and allow solo-maintainer PR merges with zero mandatory approvals while retaining required PRs, checks, conversation resolution, and admin enforcement.

## How it was verified

- Pinned `actionlint` container - all workflow files passed static validation.
- `npm run ci` - extension builds, regression tests, package validation, generated-bundle verification, and the high-severity dependency audit passed.
- GitHub API verification - secret scanning and push protection are enabled, `Secret scan` is required and bound to GitHub Actions, and branch protection retains PR/check/conversation requirements.
- Remote tag and manifest verification - every Action SHA and the actionlint digest resolves to the documented release.

## Risks, compatibility, and rollout

- No extension, website, manifest, permission, or Meta-platform behavior changes.
- The modified daily push path and release publication path require a live workflow run for final environment-level proof. After merge, manually dispatch the daily verification workflow once before enabling mandatory repository-wide SHA-pinning enforcement.
- Dependabot PRs #41, #42, and #44 overlap `ci.yml` with separate major upgrades. They should be refreshed and reviewed after this PR merges rather than merged as currently based.
- Rollback is a normal revert of this commit; repository security settings can be adjusted independently if required.

## Review map

- `.github/workflows/ci.yml` - immutable dependencies and trusted-event artifact uploads.
- `.github/workflows/daily-verification.yml` - isolated credentials for status branch and PR operations.
- `.github/workflows/publish-release.yml` - release token available only during publication.