### PR TITLE
fix(site): Smooth responsive landing page scale

### DIFF
--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -1409,6 +1409,7 @@
   width: calc(100% - 32px);
   margin: 48px 16px;
   padding: clamp(64px, 5vw, 84px) max(32px, calc((100vw - 1420px) / 2));
+  scroll-margin-top: 24px;
   overflow: hidden;
   border: 1px solid rgba(243, 238, 226, 0.12);
   border-radius: 44px;
@@ -2631,7 +2632,7 @@
   }
 
   .home-hero-copy h1 {
-    font-size: clamp(3.7rem, 10.1vw, 5.7rem);
+    font-size: clamp(3.85rem, 7.4vw, 4rem);
     white-space: normal;
   }
 
@@ -2690,6 +2691,9 @@
   .hero-detail-whale {
     display: none;
   }
+
+  .hero-detail-instagram { left: 4%; top: auto; bottom: 22%; }
+  .hero-detail-messenger { right: 4%; top: auto; bottom: 22%; }
 
   .feature-scroll {
     height: auto;
@@ -2837,7 +2841,7 @@
   }
 
   .home-hero-copy h1 {
-    font-size: clamp(3.3rem, 14.9vw, 5rem);
+    font-size: clamp(3.55rem, 10vw, 3.85rem);
     line-height: 0.9;
   }
 


### PR DESCRIPTION
## Summary

- smooth the hero headline scale across the tablet and mobile breakpoints
- keep the Instagram and Messenger hero icons away from compact-width copy
- offset the Privacy anchor so its heading clears the fixed navigation

## Why

The hero became substantially larger immediately after switching to its compact two-line layout. That breakpoint jump made narrower browser windows feel more crowded than wider layouts. The same compact range could also place decorative icons over supporting copy, while the Privacy anchor could position its heading beneath the fixed header.

## Validation

- `cd site && npm run build`
- visually reviewed every landing-page section at compact width
- verified headline sizes across the 860px and 620px breakpoints
- checked 1920, 1536, 1440, 1365, 1024, 840, 620, and 390px widths
- confirmed no horizontal overflow or browser console warnings
- confirmed the Privacy mobile-navigation destination clears the fixed header
