### PR TITLE
fix(site): Show unmerged status dates under review

### DIFF
--- a/site/src/app/components/StatusPage.tsx
+++ b/site/src/app/components/StatusPage.tsx
@@ -244,6 +244,7 @@ function buildTimelineDays(year: number, today: Date): TimelineDay[] {
   STATUS_DATA.history.forEach((event) => {
     eventsByDate.set(event.date, [...(eventsByDate.get(event.date) ?? []), event]);
   });
+  const latestMergedEventTime = Math.max(...events.map((event) => Date.parse(event.date)));
   const cellCount = 54 * 7;
 
   return Array.from({ length: cellCount }, (_, index) => {
@@ -270,6 +271,10 @@ function buildTimelineDays(year: number, today: Date): TimelineDay[] {
       tone = 'upcoming';
       label = 'Upcoming date';
       detail = 'No status is available for a future date.';
+    } else if (time > latestMergedEventTime) {
+      tone = 'review';
+      label = 'Under review';
+      detail = 'No status update has been merged for this date.';
     } else if (latestEvent) {
       tone = toneForStatus(latestEvent.publicStatus);
       label = tone === 'clear' ? 'No known issue recorded' : tone === 'issue' ? 'Known issue' : 'Under review';


### PR DESCRIPTION
## What changed

- show dates after the latest merged status entry as **Under review**
- explain that no status update has been merged for those dates
- preserve explicit event colors and historical status carry-forward before the latest merged entry

## Why

The calendar previously carried the last green status into the current day even when the daily verification PR was still unmerged. That made an unverified date look like a recorded no-issue result.

## Validation

- `npm run build` from `site/`
- production browser verification after merge