### PR TITLE
feat(site): Refine final CTA headline emphasis

### DIFF
--- a/site/src/app/components/HomePage.tsx
+++ b/site/src/app/components/HomePage.tsx
@@ -929,7 +929,10 @@ export function HomePage() {
             <span><img className="browser-logo" src="/edge-current.svg" alt="" />Edge</span>
             <span><ShieldCheck size={15} aria-hidden="true" />Free</span>
           </div>
-          <h2>Ghostify, wherever you browse.</h2>
+          <h2>
+            <span className="home-final-brand">Ghostify,</span>
+            <span className="home-final-promise">wherever you browse.</span>
+          </h2>
           <p>Quiet privacy controls for supported Meta web apps, ready in the browser you already use.</p>
           <div className="home-final-actions">
             <StoreCta />

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -2301,10 +2301,37 @@
 }
 
 .home-final h2 {
-  max-width: 940px;
-  margin-top: 38px;
-  font-size: clamp(3rem, 4.1vw, 4.75rem);
-  line-height: 0.98;
+  max-width: 1000px;
+  margin-top: 34px;
+  font-size: clamp(3.15rem, 4.45vw, 5.15rem);
+  line-height: 0.9;
+  text-wrap: balance;
+}
+
+.home-final-brand {
+  width: max-content;
+  max-width: 100%;
+  margin-inline: auto;
+  display: block;
+  color: var(--coral-dark);
+  font-family: var(--font-editorial);
+  font-size: 1.22em;
+  font-style: italic;
+  font-weight: 590;
+  letter-spacing: -0.045em;
+  line-height: 0.88;
+  font-variation-settings: 'opsz' 72;
+}
+
+.home-final-promise {
+  margin-top: 0.16em;
+  display: block;
+  font-family: var(--font-display);
+  font-size: 0.9em;
+  font-stretch: 90%;
+  font-style: normal;
+  font-weight: 540;
+  letter-spacing: -0.028em;
 }
 
 .home-final > div > p {
@@ -3225,7 +3252,12 @@
   }
 
   .home-final h2 {
-    font-size: clamp(2.5rem, 10.4vw, 3rem);
+    font-size: clamp(2.65rem, 11vw, 3.15rem);
+  }
+
+  .home-final-promise {
+    margin-top: 0.2em;
+    font-size: 0.82em;
   }
 
   .home-final-actions {


### PR DESCRIPTION
## What changed

- separates the final CTA headline into a deliberate editorial brand line and supporting promise
- reuses the existing dark-violet design token for consistent emphasis
- balances the headline scale and wrapping across desktop and mobile

## Why

The previous headline used one uniform typographic treatment, which made the closing CTA feel flat. The revised hierarchy gives the Ghostify name clearer energy without introducing decorative shapes or one-off colors.

## Validation

- `npm run build` from `site/`
- desktop and 390px mobile visual checks
- no horizontal overflow
- no relevant browser console warnings or errors