### PR TITLE
fix(site): Prevent duplicate status history entries

### DIFF
--- a/scripts/prepare-status-update.js
+++ b/scripts/prepare-status-update.js
@@ -105,7 +105,16 @@ function formatLongUtcDate(date) {
 }
 
 function prependHistory(status, item) {
-    status.history = [item, ...status.history];
+    const history = Array.isArray(status.history) ? status.history : [];
+    const isIdenticalEntry = existing => (
+        existing.date === item.date &&
+        existing.publicStatus === item.publicStatus &&
+        existing.eventType === item.eventType &&
+        existing.title === item.title &&
+        existing.summary === item.summary
+    );
+
+    status.history = [item, ...history.filter(existing => !isIdenticalEntry(existing))];
 }
 
 function assertNotBackdated(status, date) {

--- a/site/src/app/statusData.json
+++ b/site/src/app/statusData.json
@@ -189,13 +189,6 @@
     },
     {
       "date": "2026-07-16",
-      "publicStatus": "maintainer_verified",
-      "eventType": "verification",
-      "title": "All supported controls operational",
-      "summary": "All supported controls were checked on July 16, 2026 and are working normally."
-    },
-    {
-      "date": "2026-07-16",
       "publicStatus": "under_review",
       "eventType": "release",
       "title": "Ghostify 2.0.4 published",

--- a/test/prepare-status-update.test.js
+++ b/test/prepare-status-update.test.js
@@ -162,6 +162,30 @@ function testMultipleSameDayStatusUpdatesPreserveNewestFirstOrder() {
     assert.strictEqual(confirmed.history.length, source.history.length + 3);
 }
 
+function testIdenticalVerificationUpdateDoesNotDuplicateHistory() {
+    const freshDate = new Date(Date.parse(`${proposalDate}T00:00:00Z`) + 24 * 60 * 60 * 1000)
+        .toISOString()
+        .slice(0, 10);
+    const firstGeneratedAt = `${freshDate}T01:00:00Z`;
+    const first = prepareStatusUpdate(matchingReleaseStatus(), {
+        mode: 'verified',
+        date: freshDate,
+        generatedAt: firstGeneratedAt
+    });
+    const secondGeneratedAt = new Date(Date.parse(firstGeneratedAt) + 60 * 60 * 1000)
+        .toISOString()
+        .replace('.000Z', 'Z');
+    const second = prepareStatusUpdate(first, {
+        mode: 'verified',
+        date: freshDate,
+        generatedAt: secondGeneratedAt
+    });
+
+    assert.strictEqual(first.history.length, source.history.length + 1);
+    assert.strictEqual(second.history.length, first.history.length);
+    assert.deepStrictEqual(second.history[0], first.history[0]);
+}
+
 function testKnownIssueProposalUpdatesOnlySelectedControls() {
     const status = prepareStatusUpdate(source, {
         mode: 'known-issue',
@@ -253,6 +277,7 @@ testVerifiedProposalRejectsStoreBuildMismatch();
 testReportedProposalTurnsSelectedControlAndOverallStatusYellow();
 testInProgressProposalStaysYellowAndPreservesHistory();
 testMultipleSameDayStatusUpdatesPreserveNewestFirstOrder();
+testIdenticalVerificationUpdateDoesNotDuplicateHistory();
 testKnownIssueProposalUpdatesOnlySelectedControls();
 testYellowProposalRejectsUnknownControl();
 testStatusInputsRejectImpossibleDatesAndDuplicateFeatures();


### PR DESCRIPTION
## Summary
- remove the duplicate July 16 verification record from public status history
- make history updates idempotent when an identical status update is prepared again
- add regression coverage while preserving distinct same-day status transitions

## Root cause
The status preparation script always prepended a history item, so rerunning the same verification proposal could create an identical public record.

## Validation
- `node test/prepare-status-update.test.js`
- `npm run build` from `site/`
- browser verification at `/status/history` with one matching July 16 record, no horizontal overflow, and no console warnings or errors