### PR TITLE
fix(site): Clarify current status summary

### DIFF
--- a/site/src/app/components/StatusPage.tsx
+++ b/site/src/app/components/StatusPage.tsx
@@ -147,25 +147,31 @@ function StatusPill({ status, label }: { status: PublicVerificationStatus; label
 function CurrentNotice() {
   const overallStatus = getPublicReleaseStatus();
   const meta = STATUS_META[overallStatus];
-  const label = STATUS_LABELS[overallStatus];
   const heading = STATUS_DATA.summary.label;
   const message = STATUS_DATA.summary.message;
+  const buildsMatch = STATUS_DATA.release.verificationVersion === STATUS_DATA.release.publishedVersion;
 
   return (
     <section className={`status-notice status-notice-${meta.tone}`} aria-label="Current status summary">
       <div className="status-notice-head">
         <StatusIcon status={overallStatus} size={18} />
-        <strong>{label}</strong>
+        <strong>Current status</strong>
       </div>
       <div className="status-notice-body">
         <div className="status-version-row">
-          <span className="status-version-pill">Verification build v{STATUS_DATA.release.verificationVersion}</span>
-          <span className="status-version-pill">Store v{STATUS_DATA.release.publishedVersion}</span>
+          {buildsMatch ? (
+            <span className="status-version-pill">Verified build v{STATUS_DATA.release.verificationVersion}</span>
+          ) : (
+            <>
+              <span className="status-version-pill">Verification build v{STATUS_DATA.release.verificationVersion}</span>
+              <span className="status-version-pill">Store v{STATUS_DATA.release.publishedVersion}</span>
+            </>
+          )}
         </div>
         <h1>{heading}</h1>
         <p>{message}</p>
         <div className="status-notice-meta">
-          <span>{STATUS_LABELS[overallStatus]} {formatStatusDate(STATUS_DATA.generatedAt)}</span>
+          <span>Last checked {formatStatusDate(STATUS_DATA.generatedAt)}</span>
           <span>{STATUS_DATA.policy.verificationCadence}</span>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace the repeated verification label with a neutral current-status header
- collapse matching verification and store versions into one verified-build badge
- present the verification timestamp as a clear last-checked value

## Why
The status summary repeated the same verification message and gave two identical version badges equal visual weight. This update creates a clearer hierarchy while preserving separate badges whenever the versions differ.

## Validation
- site build passes
- desktop and mobile visual checks pass without horizontal overflow
- status calendar interaction works
- browser console has no warnings or errors