### PR TITLE
chore(release): Preserve package identity and fixture privacy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6

--- a/.github/workflows/daily-verification.yml
+++ b/.github/workflows/daily-verification.yml
@@ -192,6 +192,8 @@ jobs:
 
           Merge only after manually verifying the supported controls. Until this PR is merged, the website and popup keep showing the latest previously merged status.
 
+          - [ ] I tested the extension installed from the Chrome Web Store, not an unpacked development build.
+
           - [ ] GH-IG-SEEN-001
           - [ ] GH-IG-TYPING-001
           - [ ] GH-IG-STORY-001

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: Release version from package.json (for example, 2.0.5)
+        description: Release version from package.json (for example, 2.0.6)
         required: true
         type: string
       chrome_web_store_approved:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,6 @@ grouped by version, with the most recent changes first.
   release, and product-update history no longer overrides popup verification.
 - Removed the redundant Chrome Web Store link and version-mismatch warning from
   the status summary card; the header remains the single installation action.
-- Prevented duplicate public-status history entries during repeated proposals.
 
 ## [2.0.5] - 2026-07-17
 
@@ -66,6 +65,7 @@ grouped by version, with the most recent changes first.
 
 ### Fixed
 
+- Prevented duplicate public-status history entries during repeated proposals.
 - Removed unnecessary platform-link hover motion and corrected the Facebook
   icon's optical size.
 - Prevented long popup tooltips from overflowing or leaving one-sided empty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,23 @@ grouped by version, with the most recent changes first.
 - Added an explicit Chrome Web Store artifact confirmation to the maintainer's
   live-verification checklist so an unpacked development build cannot be
   mistaken for the published package.
+- Added Firefox desktop package preparation, validation, linting, deterministic
+  extension and reviewer-source archives, and AMO submission documentation.
+- Added maintainer ownership, private vulnerability reporting, and threat-model
+  documentation for the project's security and release boundaries.
 
 ### Changed
 
 - Advanced the repository package identity to `2.0.6` so changes made after
   the published `2.0.5` tag cannot produce a second, different `2.0.5` ZIP.
+- Replaced the legacy persisted configuration path with packaged,
+  version-checked configuration and restricted page-bridge inputs to known
+  settings and runtime pattern keys.
+- Strengthened release checks with deterministic cross-platform ZIP output,
+  exact approved-artifact hash matching, pinned Firefox tooling, dependency
+  audits, and deploy-time website security headers.
+- Reworked the website's privacy and verification evidence to link directly to
+  public project records.
 
 ### Fixed
 
@@ -31,6 +43,7 @@ grouped by version, with the most recent changes first.
   release, and product-update history no longer overrides popup verification.
 - Removed the redundant Chrome Web Store link and version-mismatch warning from
   the status summary card; the header remains the single installation action.
+- Prevented duplicate public-status history entries during repeated proposals.
 
 ## [2.0.5] - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,23 @@ section, and GitHub Releases should match the facts recorded here.
 The format follows the spirit of Keep a Changelog: human-written entries,
 grouped by version, with the most recent changes first.
 
-## [Unreleased]
+## [2.0.6] - Unreleased
+
+### Added
+
+- Added an explicit Chrome Web Store artifact confirmation to the maintainer's
+  live-verification checklist so an unpacked development build cannot be
+  mistaken for the published package.
+
+### Changed
+
+- Advanced the repository package identity to `2.0.6` so changes made after
+  the published `2.0.5` tag cannot produce a second, different `2.0.5` ZIP.
 
 ### Fixed
 
+- Replaced production-shaped conversation labels and identifiers in Messenger
+  regression fixtures with clearly synthetic values.
 - Separated the published verification target from the repository version so
   reviewed status updates can remain accurate without requiring an extension
   release, and product-update history no longer overrides popup verification.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ publicly available store install.
 
 Use the Chrome Web Store badge above for the current published version. GitHub
 [Releases](https://github.com/Hendrizzzz/Ghostify/releases) contain source
-release notes when a matching GitHub release has been published.
+release notes when a matching GitHub release has been published. The repository
+may be prepared at the next version while Store review or release work is still
+pending; `site/src/app/statusData.json` records those identities separately.
 
 ## How It Works
 

--- a/dist/config/patterns.json
+++ b/dist/config/patterns.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.5",
+    "version": "2.0.6",
     "killSwitch": [],
     "patterns": {
         "igTyping": [

--- a/dist/js/content.js
+++ b/dist/js/content.js
@@ -64,7 +64,7 @@
 
   // src/content.js
   var FALLBACK_CONFIG = {
-    version: "2.0.5",
+    version: "2.0.6",
     killSwitch: [],
     patterns: {
       igTyping: ["indicate_activity", "typing_indicator", "activity_indicator", "is_typing", "direct_v2/threads/broadcast/typing", "direct_v2/threads/typing", "sendtypingindicator", "send_typing_indicator", "typing_on", "is_composing"],

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Ghostify | Hide Seen, Typing & Story Views",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "description": "Control your visibility on Instagram & Facebook/Messenger. Hide typing indicators, read receipts, and story views.",
     "author": "Hendrizzzz",
     "permissions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghostify",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghostify",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.28.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghostify",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "private": true,
   "description": "Privacy controls for Instagram, Facebook, and Messenger.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Privacy controls for Instagram, Facebook, and Messenger.",
   "scripts": {
     "build": "node build.js",
-    "test": "npm run build && npm run test:modules && node test/messenger-send-stability.test.js && npm run test:status && npm run test:release-notes && npm run test:validator && npm run test:package",
+    "test": "npm run build && npm run test:modules && node test/messenger-send-stability.test.js && npm run test:status && npm run test:release-notes && npm run test:tag-integrity && npm run test:validator && npm run test:package",
     "test:modules": "npm run test:modules:shared && node test/firefox-popup.test.js",
     "test:modules:shared": "node test/settings-defaults.test.js && node test/runtime-config.test.js && node test/module-registry.test.js && node test/module-flags.test.js",
     "test:popup:chromium": "node test/firefox-popup.test.js chromium",
@@ -13,6 +13,7 @@
     "test:validator": "node test/validate-extension-package.test.js",
     "test:status": "node test/prepare-status-update.test.js && node test/daily-verification-git.test.js",
     "test:release-notes": "node test/extract-release-notes.test.js",
+    "test:tag-integrity": "node test/version-tag-integrity.test.js",
     "test:package": "npm run test:package:chromium && npm run test:package:firefox",
     "test:package:chromium": "node test/package-extension.test.js",
     "test:package:firefox": "node test/package-firefox.test.js",
@@ -22,12 +23,13 @@
     "package:firefox": "node scripts/package-firefox.js",
     "validate:extension": "node scripts/validate-extension-package.js",
     "validate:firefox": "node scripts/validate-firefox-extension.js",
+    "validate:tag-integrity": "node scripts/validate-version-tag-integrity.js",
     "lint:firefox": "npm run prepare:firefox && web-ext lint --source-dir tmp/firefox-extension --warnings-as-errors",
     "verify:dist": "git diff --exit-code -- dist/background.js dist/js/content.js dist/js/ghost.js dist/js/messenger_patch.js",
     "audit:high": "npm audit --audit-level=high",
-    "ci:chromium": "npm run build && npm run test:modules:shared && npm run test:popup:chromium && node test/messenger-send-stability.test.js && npm run test:status && npm run test:release-notes && npm run test:validator && npm run test:package:chromium && npm run validate:extension && npm run verify:dist && npm run audit:high",
+    "ci:chromium": "npm run build && npm run test:modules:shared && npm run test:popup:chromium && node test/messenger-send-stability.test.js && npm run test:status && npm run test:release-notes && npm run test:tag-integrity && npm run test:validator && npm run test:package:chromium && npm run validate:extension && npm run validate:tag-integrity && npm run verify:dist && npm run audit:high",
     "ci:firefox": "npm run build && npm run test:modules:shared && npm run test:popup:firefox && node test/messenger-send-stability.test.js && npm run test:package:firefox && npm run validate:firefox && npm run lint:firefox && npm run verify:dist && npm run audit:high",
-    "ci": "npm test && npm run validate:extension && npm run validate:firefox && npm run lint:firefox && npm run verify:dist && npm run audit:high"
+    "ci": "npm test && npm run validate:extension && npm run validate:firefox && npm run validate:tag-integrity && npm run lint:firefox && npm run verify:dist && npm run audit:high"
   },
   "repository": {
     "type": "git",

--- a/scripts/extract-release-notes.js
+++ b/scripts/extract-release-notes.js
@@ -22,6 +22,33 @@ function extractReleaseNotes(changelog, version) {
     return notes;
 }
 
+function assertDatedReleaseHeading(changelog, version) {
+    if (!/^\d+\.\d+\.\d+$/.test(version)) {
+        throw new Error('Release version must use X.Y.Z format.');
+    }
+
+    const headingPattern = new RegExp(
+        `^## \\[${escapeRegExp(version)}\\] - (\\d{4}-\\d{2}-\\d{2})$`,
+        'm'
+    );
+    const match = headingPattern.exec(changelog);
+    if (!match) {
+        throw new Error(`CHANGELOG.md release ${version} must have a dated YYYY-MM-DD heading before publication.`);
+    }
+
+    const [year, month, day] = match[1].split('-').map(Number);
+    const parsed = new Date(Date.UTC(year, month - 1, day));
+    if (
+        parsed.getUTCFullYear() !== year ||
+        parsed.getUTCMonth() !== month - 1 ||
+        parsed.getUTCDate() !== day
+    ) {
+        throw new Error(`CHANGELOG.md release ${version} has an invalid publication date.`);
+    }
+
+    return match[1];
+}
+
 function main(argv) {
     const [version, changelogPath = 'CHANGELOG.md'] = argv;
     if (!version || argv.length > 2) {
@@ -29,6 +56,7 @@ function main(argv) {
     }
 
     const changelog = fs.readFileSync(path.resolve(changelogPath), 'utf8');
+    assertDatedReleaseHeading(changelog, version);
     process.stdout.write(`${extractReleaseNotes(changelog, version)}\n`);
 }
 
@@ -41,4 +69,4 @@ if (require.main === module) {
     }
 }
 
-module.exports = { extractReleaseNotes };
+module.exports = { assertDatedReleaseHeading, extractReleaseNotes };

--- a/scripts/validate-version-tag-integrity.js
+++ b/scripts/validate-version-tag-integrity.js
@@ -3,7 +3,7 @@ const fs = require('fs');
 const path = require('path');
 
 const PACKAGE_IDENTITY_PATHS = [
-    'browser-targets/firefox-manifest-overrides.json',
+    'browser-targets/firefox',
     'dist',
     'scripts/lib/deterministic-zip.js',
     'scripts/package-extension.js',

--- a/scripts/validate-version-tag-integrity.js
+++ b/scripts/validate-version-tag-integrity.js
@@ -1,0 +1,68 @@
+const childProcess = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const PACKAGE_IDENTITY_PATHS = [
+    'browser-targets/firefox-manifest-overrides.json',
+    'dist',
+    'scripts/lib/deterministic-zip.js',
+    'scripts/package-extension.js',
+    'scripts/package-firefox.js',
+    'scripts/prepare-firefox-extension.js'
+];
+
+function git(repoRoot, args) {
+    return childProcess.spawnSync('git', args, {
+        cwd: repoRoot,
+        encoding: 'utf8'
+    });
+}
+
+function failFromGit(result, fallback) {
+    const detail = (result.stderr || result.stdout || '').trim();
+    throw new Error(detail || fallback);
+}
+
+function validateVersionTagIntegrity(repoRoot = process.cwd()) {
+    const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+    if (!pkg.version || !/^\d+\.\d+\.\d+$/.test(pkg.version)) {
+        throw new Error('package.json version must use X.Y.Z format.');
+    }
+
+    const tag = `v${pkg.version}`;
+    const tagLookup = git(repoRoot, ['rev-parse', '--verify', '--quiet', `refs/tags/${tag}^{commit}`]);
+    if (tagLookup.status === 1) return { status: 'untagged', tag, changedPaths: [] };
+    if (tagLookup.status !== 0) failFromGit(tagLookup, `Could not inspect ${tag}.`);
+
+    const comparison = git(repoRoot, ['diff', '--quiet', tag, '--', ...PACKAGE_IDENTITY_PATHS]);
+    if (comparison.status === 0) return { status: 'matched', tag, changedPaths: [] };
+    if (comparison.status !== 1) failFromGit(comparison, `Could not compare package inputs with ${tag}.`);
+
+    const changed = git(repoRoot, ['diff', '--name-only', tag, '--', ...PACKAGE_IDENTITY_PATHS]);
+    if (changed.status !== 0) failFromGit(changed, `Could not list package input changes since ${tag}.`);
+    const changedPaths = changed.stdout.trim().split(/\r?\n/).filter(Boolean);
+    throw new Error(
+        `${tag} already identifies different packaged extension inputs. ` +
+        `Advance package.json to the next unused version before changing: ${changedPaths.join(', ')}`
+    );
+}
+
+function main() {
+    const result = validateVersionTagIntegrity();
+    if (result.status === 'untagged') {
+        console.log(`${result.tag} is not tagged; package identity is available for the current development version`);
+    } else {
+        console.log(`packaged extension inputs still match ${result.tag}`);
+    }
+}
+
+if (require.main === module) {
+    try {
+        main();
+    } catch (error) {
+        console.error(error.message);
+        process.exitCode = 1;
+    }
+}
+
+module.exports = { PACKAGE_IDENTITY_PATHS, validateVersionTagIntegrity };

--- a/site/src/app/statusData.json
+++ b/site/src/app/statusData.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "product": "Ghostify",
-  "productVersion": "2.0.5",
+  "productVersion": "2.0.6",
   "generatedAt": "2026-07-20T04:01:28Z",
   "release": {
     "channel": "Chrome Web Store",

--- a/src/content.js
+++ b/src/content.js
@@ -2,7 +2,7 @@ import { GHOSTIFY_SETTINGS_STORAGE_KEY, sanitizePrivacySettingsForPage } from '.
 import { normalizePackagedConfig } from './runtime-config.js';
 
 const FALLBACK_CONFIG = {
-    version: "2.0.5",
+    version: "2.0.6",
     killSwitch: [],
     patterns: {
         igTyping: ['indicate_activity', 'typing_indicator', 'activity_indicator', 'is_typing', 'direct_v2/threads/broadcast/typing', 'direct_v2/threads/typing', 'sendtypingindicator', 'send_typing_indicator', 'typing_on', 'is_composing'],

--- a/test/daily-verification-git.test.js
+++ b/test/daily-verification-git.test.js
@@ -4,6 +4,12 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
+const workflow = fs.readFileSync('.github/workflows/daily-verification.yml', 'utf8');
+assert(
+    workflow.includes('I tested the extension installed from the Chrome Web Store, not an unpacked development build.'),
+    'daily verification PRs must identify the tested Store-installed artifact'
+);
+
 function git(cwd, args, options = {}) {
     return childProcess.spawnSync('git', args, {
         cwd,

--- a/test/extract-release-notes.test.js
+++ b/test/extract-release-notes.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const fs = require('fs');
 
-const { extractReleaseNotes } = require('../scripts/extract-release-notes');
+const { assertDatedReleaseHeading, extractReleaseNotes } = require('../scripts/extract-release-notes');
 
 const changelog = fs.readFileSync('CHANGELOG.md', 'utf8');
 const pkg = require('../package.json');
@@ -19,6 +19,18 @@ assert.throws(
     /has no notes/
 );
 assert.throws(() => extractReleaseNotes(changelog, 'release-2.0.4'), /must use X.Y.Z format/);
+assert.strictEqual(
+    assertDatedReleaseHeading('## [1.2.3] - 2026-07-20\n\n- Release notes.', '1.2.3'),
+    '2026-07-20'
+);
+assert.throws(
+    () => assertDatedReleaseHeading('## [1.2.3] - Unreleased\n\n- Release notes.', '1.2.3'),
+    /must have a dated YYYY-MM-DD heading/
+);
+assert.throws(
+    () => assertDatedReleaseHeading('## [1.2.3] - 2026-02-30\n\n- Release notes.', '1.2.3'),
+    /invalid publication date/
+);
 
 assert(
     publishWorkflow.includes('chrome_web_store_sha256') &&

--- a/test/messenger-send-stability.test.js
+++ b/test/messenger-send-stability.test.js
@@ -324,11 +324,11 @@ const messengerReadReceipt = JSON.stringify({
     }]
 });
 
-const facebookWorkerEdgeChatReadWatermarkFrame = new Uint8Array(Buffer.from(`{}\r\u0000{"app_id":"2220391788200892","payload":"{\\"epoch_id\\":7466158453245587268,\\"tasks\\":[{\\"failure_count\\":null,\\"label\\":\\"21\\",\\"payload\\":\\"{\\\\\\"thread_id\\\\\\":9554524854659116,\\\\\\"last_read_watermark_ts\\\\\\":1780070888819,\\\\\\"sync_group\\\\\\":104}\\",\\"queue_name\\":\\"9554524854659116\\",\\"task_id\\":409}],\\"version_id\\":\\"27029912679952307\\"}","request_id":167,"type":3}`, 'utf8'));
+const facebookWorkerEdgeChatReadWatermarkFrame = new Uint8Array(Buffer.from(`{}\r\u0000{"app_id":"2220391788200892","payload":"{\\"epoch_id\\":7466158453245587268,\\"tasks\\":[{\\"failure_count\\":null,\\"label\\":\\"21\\",\\"payload\\":\\"{\\\\\\"thread_id\\\\\\":9000000000000001,\\\\\\"last_read_watermark_ts\\\\\\":1780070888819,\\\\\\"sync_group\\\\\\":104}\\",\\"queue_name\\":\\"9000000000000001\\",\\"task_id\\":409}],\\"version_id\\":\\"27029912679952307\\"}","request_id":167,"type":3}`, 'utf8'));
 
-const facebookWorkerEdgeChatLastSeenFrame = new Uint8Array(Buffer.from(`{}\r\u0000{"app_id":"2220391788200892","payload":"{\\"label\\":\\"6\\",\\"payload\\":\\"{\\\\\\"parent_thread_key\\\\\\":1369182074351833,\\\\\\"last_seen_time_ms\\\\\\":1780070890716}\\",\\"version\\":\\"27029912679952307\\"}","request_id":179,"type":4}`, 'utf8'));
+const facebookWorkerEdgeChatLastSeenFrame = new Uint8Array(Buffer.from(`{}\r\u0000{"app_id":"2220391788200892","payload":"{\\"label\\":\\"6\\",\\"payload\\":\\"{\\\\\\"parent_thread_key\\\\\\":1000000000000002,\\\\\\"last_seen_time_ms\\\\\\":1780070890716}\\",\\"version\\":\\"27029912679952307\\"}","request_id":179,"type":4}`, 'utf8'));
 
-const facebookWorkerEdgeChatDeliveryFrame = new Uint8Array(Buffer.from(`{}\r\u0000{"app_id":"2220391788200892","payload":"{\\"label\\":\\"delivery\\",\\"payload\\":\\"{\\\\\\"thread_id\\\\\\":9554524854659116,\\\\\\"delivery_receipt\\\\\\":true}\\",\\"version\\":\\"27029912679952307\\"}","request_id":180,"type":4}`, 'utf8'));
+const facebookWorkerEdgeChatDeliveryFrame = new Uint8Array(Buffer.from(`{}\r\u0000{"app_id":"2220391788200892","payload":"{\\"label\\":\\"delivery\\",\\"payload\\":\\"{\\\\\\"thread_id\\\\\\":9000000000000001,\\\\\\"delivery_receipt\\\\\\":true}\\",\\"version\\":\\"27029912679952307\\"}","request_id":180,"type":4}`, 'utf8'));
 
 const facebookEdgeChatMixedOpaqueSendTypingFrame = new Uint8Array(Buffer.from(`{}\r\u0000${JSON.stringify({
     app_id: '2220391788200892',
@@ -338,23 +338,23 @@ const facebookEdgeChatMixedOpaqueSendTypingFrame = new Uint8Array(Buffer.from(`{
             failure_count: null,
             label: '46',
             payload: JSON.stringify({
-                thread_id: 9554524854659116,
+                thread_id: 9000000000000001,
                 offline_threading_id: 'redacted-offline-id',
                 send_type: 1,
                 message: { text: 'markThreadAsRead readReceipt' },
                 sync_group: 104
             }),
-            queue_name: '9554524854659116',
+            queue_name: '9000000000000001',
             task_id: 410
         }, {
             failure_count: null,
             label: 'sendChatStateFromComposer',
             payload: JSON.stringify({
-                thread_id: 9554524854659116,
+                thread_id: 9000000000000001,
                 chatstate: 'typing_indicator',
                 send_type: 'typing'
             }),
-            queue_name: '9554524854659116',
+            queue_name: '9000000000000001',
             task_id: 411
         }],
         version_id: '27029912679952307'
@@ -398,11 +398,11 @@ const facebookEdgeChatQuickReactionSendTypingFrame = new Uint8Array(Buffer.from(
     type: 3
 })}`, 'utf8'));
 
-const facebookFeedThreadOpenFullFetchFrame = new Uint8Array(Buffer.from(`\u000fg\u0000\u0002\u0000\u0000{}\rg\u0000\u0000{"app_id":"2220391788200892","payload":"{\\"epoch_id\\":7466175527281646890,\\"tasks\\":[{\\"failure_count\\":null,\\"label\\":\\"209\\",\\"payload\\":\\"{\\\\\\"thread_fbid\\\\\\":1594581527264656,\\\\\\"force_upsert\\\\\\":0,\\\\\\"use_open_messenger_transport\\\\\\":0,\\\\\\"sync_group\\\\\\":95,\\\\\\"metadata_only\\\\\\":0,\\\\\\"preview_only\\\\\\":0}\\",\\"queue_name\\":\\"1594581527264656\\",\\"task_id\\":238}],\\"version_id\\":\\"27029912679952307\\"}","request_id":107,"type":3}`, 'utf8'));
+const facebookFeedThreadOpenFullFetchFrame = new Uint8Array(Buffer.from(`\u000fg\u0000\u0002\u0000\u0000{}\rg\u0000\u0000{"app_id":"2220391788200892","payload":"{\\"epoch_id\\":7466175527281646890,\\"tasks\\":[{\\"failure_count\\":null,\\"label\\":\\"209\\",\\"payload\\":\\"{\\\\\\"thread_fbid\\\\\\":1000000000000003,\\\\\\"force_upsert\\\\\\":0,\\\\\\"use_open_messenger_transport\\\\\\":0,\\\\\\"sync_group\\\\\\":95,\\\\\\"metadata_only\\\\\\":0,\\\\\\"preview_only\\\\\\":0}\\",\\"queue_name\\":\\"1000000000000003\\",\\"task_id\\":238}],\\"version_id\\":\\"27029912679952307\\"}","request_id":107,"type":3}`, 'utf8'));
 
-const facebookFeedArmadilloOpenThreadFrame = new Uint8Array(Buffer.from(`\u000fg\u0000\u0002\u0000\u0000{}\rg\u0000\u0000{"app_id":"2220391788200892","payload":"{\\"epoch_id\\":7466178972558867308,\\"tasks\\":[{\\"failure_count\\":null,\\"label\\":\\"436\\",\\"payload\\":\\"{\\\\\\"open_message_thread_key\\\\\\":61557782315684,\\\\\\"armadillo_thread_key\\\\\\":61557782315684,\\\\\\"trace_id\\\\\\":\\\\\\"41AA1952E6DBA5E1\\\\\\",\\\\\\"should_copy_messages\\\\\\":0}\\",\\"queue_name\\":\\"61557782315684_61557782315684\\",\\"task_id\\":391}],\\"version_id\\":\\"27029912679952307\\"}","request_id":145,"type":3}`, 'utf8'));
+const facebookFeedArmadilloOpenThreadFrame = new Uint8Array(Buffer.from(`\u000fg\u0000\u0002\u0000\u0000{}\rg\u0000\u0000{"app_id":"2220391788200892","payload":"{\\"epoch_id\\":7466178972558867308,\\"tasks\\":[{\\"failure_count\\":null,\\"label\\":\\"436\\",\\"payload\\":\\"{\\\\\\"open_message_thread_key\\\\\\":10000000000004,\\\\\\"armadillo_thread_key\\\\\\":10000000000004,\\\\\\"trace_id\\\\\\":\\\\\\"0000000000000001\\\\\\",\\\\\\"should_copy_messages\\\\\\":0}\\",\\"queue_name\\":\\"10000000000004_10000000000004\\",\\"task_id\\":391}],\\"version_id\\":\\"27029912679952307\\"}","request_id":145,"type":3}`, 'utf8'));
 
-const facebookFeedThreadOpenWithReadMetadataFrame = new Uint8Array(Buffer.from(`\u000fg\u0000\u0002\u0000\u0000{}\rg\u0000\u0000{"app_id":"2220391788200892","payload":"{\\"epoch_id\\":7466175527281646891,\\"tasks\\":[{\\"failure_count\\":null,\\"label\\":\\"209\\",\\"payload\\":\\"{\\\\\\"thread_fbid\\\\\\":1594581527264656,\\\\\\"last_read_watermark\\\\\\":1780070888819,\\\\\\"force_upsert\\\\\\":0,\\\\\\"metadata_only\\\\\\":0,\\\\\\"preview_only\\\\\\":0}\\",\\"queue_name\\":\\"1594581527264656\\",\\"task_id\\":239}],\\"version_id\\":\\"27029912679952307\\"}","request_id":108,"type":3}`, 'utf8'));
+const facebookFeedThreadOpenWithReadMetadataFrame = new Uint8Array(Buffer.from(`\u000fg\u0000\u0002\u0000\u0000{}\rg\u0000\u0000{"app_id":"2220391788200892","payload":"{\\"epoch_id\\":7466175527281646891,\\"tasks\\":[{\\"failure_count\\":null,\\"label\\":\\"209\\",\\"payload\\":\\"{\\\\\\"thread_fbid\\\\\\":1000000000000003,\\\\\\"last_read_watermark\\\\\\":1780070888819,\\\\\\"force_upsert\\\\\\":0,\\\\\\"metadata_only\\\\\\":0,\\\\\\"preview_only\\\\\\":0}\\",\\"queue_name\\":\\"1000000000000003\\",\\"task_id\\":239}],\\"version_id\\":\\"27029912679952307\\"}","request_id":108,"type":3}`, 'utf8'));
 
 const facebookFramePrefix = '\u000fg\u0000\u0002\u0000\u0000{}\rg\u0000\u0000';
 const facebookFramedRestoredGroupInnerPayload = JSON.stringify({
@@ -7430,7 +7430,7 @@ function testFacebookUnreadFeedMessageClicksKeepDocumentVisibleForThreadLoading(
     window.document.dispatchEvent({
         type: 'pointerdown',
         target: createRequestClickTarget({
-            label: 'Jayy Zz Unread message: testing 17 · 1m'
+            label: 'Synthetic Contact Unread message: fixture 17 · 1m'
         })
     });
 
@@ -7468,8 +7468,8 @@ function testFacebookUnreadFeedMessageChildClicksKeepDocumentVisibleForThreadLoa
     window.__GHOSTIFY_FACEBOOK_ROOT_NATIVE_UNTIL__ = Date.now() - 1;
     const row = {
         parentElement: null,
-        innerText: 'Jayy Zz Unread message: testing 18 · 1m',
-        textContent: 'Jayy Zz Unread message: testing 18 · 1m',
+        innerText: 'Synthetic Contact Unread message: fixture 18 · 1m',
+        textContent: 'Synthetic Contact Unread message: fixture 18 · 1m',
         getAttribute() { return ''; },
         closest() { return this; }
     };
@@ -7962,7 +7962,7 @@ function testFacebookNestedMessageRequestClicksTemporarilyRestoreNativeFocus() {
     facebookWindow.document.dispatchEvent({
         type: 'click',
         target: createNestedRequestClickTarget({
-            parentLabel: 'New message requests From Princess Hannah Bermudez and others',
+            parentLabel: 'New message requests From Synthetic Contact and others',
             childLabel: ''
         })
     });
@@ -7997,8 +7997,8 @@ function testFacebookNormalConversationClicksDoNotInheritSiblingMessageRequestTe
     facebookWindow.document.dispatchEvent({
         type: 'click',
         target: createNestedConversationClickTargetWithRequestSibling({
-            rowLabel: 'Jayy Zz You: thumbs up 2d',
-            containerLabel: 'New message requests From Princess Hannah Bermudez Jayy Zz You: thumbs up 2d'
+            rowLabel: 'Synthetic Contact You: thumbs up 2d',
+            containerLabel: 'New message requests From Synthetic Contact Synthetic Contact You: thumbs up 2d'
         })
     });
 

--- a/test/runtime-config.test.js
+++ b/test/runtime-config.test.js
@@ -4,7 +4,7 @@ const { loadSrcModule } = require('./helpers/load-src-module');
 const { normalizePackagedConfig } = loadSrcModule('src/runtime-config.js');
 
 const fallbackConfig = {
-    version: '2.0.5',
+    version: '9.9.9',
     patterns: {
         igSeen: ['mark_seen'],
         msgSeen: ['mark_read']
@@ -13,16 +13,16 @@ const fallbackConfig = {
 
 assert.strictEqual(normalizePackagedConfig(null, fallbackConfig), null);
 assert.strictEqual(normalizePackagedConfig([], fallbackConfig), null);
-assert.strictEqual(normalizePackagedConfig({ version: '2.0.4', patterns: {} }, fallbackConfig), null);
-assert.strictEqual(normalizePackagedConfig({ version: '2.0.5' }, fallbackConfig), null);
+assert.strictEqual(normalizePackagedConfig({ version: '9.9.8', patterns: {} }, fallbackConfig), null);
+assert.strictEqual(normalizePackagedConfig({ version: '9.9.9' }, fallbackConfig), null);
 assert.strictEqual(
-    normalizePackagedConfig({ version: '2.0.5', patterns: { igSeen: [] } }, fallbackConfig),
+    normalizePackagedConfig({ version: '9.9.9', patterns: { igSeen: [] } }, fallbackConfig),
     null,
     'every known pattern key must be present as an array'
 );
 
 const normalized = normalizePackagedConfig({
-    version: '2.0.5',
+    version: '9.9.9',
     killSwitch: ['msgSeen', 'unknown', 'msgSeen', 42],
     patterns: {
         igSeen: [' mark_seen ', '', 42, 'a'.repeat(97), 'unsafe(pattern)'],

--- a/test/version-tag-integrity.test.js
+++ b/test/version-tag-integrity.test.js
@@ -23,6 +23,7 @@ function createTaggedFixture() {
     git(root, ['config', 'user.name', 'Ghostify test']);
     git(root, ['config', 'user.email', 'ghostify-test@example.invalid']);
     write(root, 'package.json', '{"version":"1.2.3"}\n');
+    write(root, 'browser-targets/firefox/manifest.overlay.json', '{"name":"fixture"}\n');
     write(root, 'dist/manifest.json', '{"version":"1.2.3"}\n');
     write(root, 'scripts/package-extension.js', 'module.exports = {};\n');
     write(root, 'README.md', '# Fixture\n');
@@ -55,6 +56,20 @@ try {
     assert.throws(
         () => validateVersionTagIntegrity(changedPackage),
         /v1\.2\.3 already identifies different packaged extension inputs.*dist\/manifest\.json/
+    );
+
+    const changedFirefoxOverlay = createTaggedFixture();
+    fixtureRoots.push(changedFirefoxOverlay);
+    write(
+        changedFirefoxOverlay,
+        'browser-targets/firefox/manifest.overlay.json',
+        '{"name":"changed fixture"}\n'
+    );
+    git(changedFirefoxOverlay, ['add', '--', 'browser-targets/firefox/manifest.overlay.json']);
+    git(changedFirefoxOverlay, ['commit', '-m', 'change Firefox package overlay']);
+    assert.throws(
+        () => validateVersionTagIntegrity(changedFirefoxOverlay),
+        /v1\.2\.3 already identifies different packaged extension inputs.*browser-targets\/firefox\/manifest\.overlay\.json/
     );
 
     write(changedPackage, 'package.json', '{"version":"1.2.4"}\n');

--- a/test/version-tag-integrity.test.js
+++ b/test/version-tag-integrity.test.js
@@ -1,0 +1,68 @@
+const assert = require('assert');
+const childProcess = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { validateVersionTagIntegrity } = require('../scripts/validate-version-tag-integrity');
+
+function git(cwd, args) {
+    const result = childProcess.spawnSync('git', args, { cwd, encoding: 'utf8' });
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+}
+
+function write(root, relativePath, contents) {
+    const destination = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.writeFileSync(destination, contents);
+}
+
+function createTaggedFixture() {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ghostify-version-tag-'));
+    git(root, ['init']);
+    git(root, ['config', 'user.name', 'Ghostify test']);
+    git(root, ['config', 'user.email', 'ghostify-test@example.invalid']);
+    write(root, 'package.json', '{"version":"1.2.3"}\n');
+    write(root, 'dist/manifest.json', '{"version":"1.2.3"}\n');
+    write(root, 'scripts/package-extension.js', 'module.exports = {};\n');
+    write(root, 'README.md', '# Fixture\n');
+    git(root, ['add', '--', '.']);
+    git(root, ['commit', '-m', 'fixture release']);
+    git(root, ['tag', 'v1.2.3']);
+    return root;
+}
+
+const fixtureRoots = [];
+try {
+    const unchanged = createTaggedFixture();
+    fixtureRoots.push(unchanged);
+    assert.deepStrictEqual(validateVersionTagIntegrity(unchanged), {
+        status: 'matched',
+        tag: 'v1.2.3',
+        changedPaths: []
+    });
+
+    write(unchanged, 'README.md', '# Documentation-only change\n');
+    git(unchanged, ['add', '--', 'README.md']);
+    git(unchanged, ['commit', '-m', 'docs update']);
+    assert.strictEqual(validateVersionTagIntegrity(unchanged).status, 'matched');
+
+    const changedPackage = createTaggedFixture();
+    fixtureRoots.push(changedPackage);
+    write(changedPackage, 'dist/manifest.json', '{"version":"1.2.3","description":"changed"}\n');
+    git(changedPackage, ['add', '--', 'dist/manifest.json']);
+    git(changedPackage, ['commit', '-m', 'change packaged input']);
+    assert.throws(
+        () => validateVersionTagIntegrity(changedPackage),
+        /v1\.2\.3 already identifies different packaged extension inputs.*dist\/manifest\.json/
+    );
+
+    write(changedPackage, 'package.json', '{"version":"1.2.4"}\n');
+    git(changedPackage, ['add', '--', 'package.json']);
+    git(changedPackage, ['commit', '-m', 'advance version']);
+    assert.strictEqual(validateVersionTagIntegrity(changedPackage).status, 'untagged');
+} finally {
+    for (const root of fixtureRoots) fs.rmSync(root, { recursive: true, force: true });
+}
+
+console.log('version-tag package identity tests passed');


### PR DESCRIPTION
## Summary

- advance the repository and generated package identity to unreleased v2.0.6 while keeping the published and verified Chrome Web Store release recorded as v2.0.5
- reject future packaged-extension changes that reuse an already-tagged version, while allowing website, status, and documentation-only maintenance
- require a dated changelog heading before the release-note command can publish a GitHub release
- replace production-shaped Messenger conversation labels and identifiers in regression fixtures with synthetic values
- require future green verification PRs to confirm the Chrome Web Store-installed artifact was tested
- document the repository-versus-Store version distinction and the substantive post-v2.0.5 work

## Why

The v2.0.5 tag already identifies the package published through the Chrome Web Store, but later changes on `main` still carried the same extension version. That allowed a second, different ZIP to be generated as v2.0.5. The new tag-integrity guard prevents this pattern from recurring after a version is tagged. Separately, several regression fixtures retained production-shaped conversation data that was unnecessary for test coverage.

## Impact

This PR does not change Ghostify's runtime behavior and does not publish or submit v2.0.6 to any browser store. It gives future release packages an unambiguous identity, reduces privacy risk in public fixtures, and makes live verification evidence clearer about which artifact was tested.

## Validation

- `npm ci`
- `npm run ci`
- `npm ci` and `npm run build` in `site/`
- `npm run package:extension`
- generated `ghostify-v2.0.6-chrome-web-store.zip` SHA-256: `bb8df67a88aaf88fe0e07e44b185328519e58f173dba94d08debe126535ee95b`
- unit coverage for tagged-package drift, documentation-only post-tag changes, unused next versions, dated changelog headings, and invalid dates
- repository scan confirms the replaced names and identifiers are absent from the current tree

## Manual follow-up

After merge, test the extension installed from the Chrome Web Store rather than an unpacked development build and publish the next verification update only after that matrix passes. Do not upload the locally generated v2.0.6 package until its intended release scope, dated changelog, and Store metadata are reviewed.