### PR TITLE
fix(ci): Keep daily verification resilient to tooling advisories

### DIFF
--- a/.github/workflows/daily-verification.yml
+++ b/.github/workflows/daily-verification.yml
@@ -138,7 +138,20 @@ jobs:
 
       - name: Validate extension and status contract
         if: steps.eligible.outputs.ready == 'true'
-        run: npm run ci
+        run: npm run ci:verification
+
+      - name: Report development-tool advisories
+        id: tooling-audit
+        if: steps.eligible.outputs.ready == 'true'
+        continue-on-error: true
+        run: npm run audit:high
+
+      - name: Record development-tool advisory warning
+        if: steps.tooling-audit.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::A development-tool advisory needs maintainer review, but it does not block the daily live-verification proposal."
+          echo "Development-tool audit reported an advisory. Normal pull-request CI remains blocking until it is resolved." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Install site dependencies
         if: steps.eligible.outputs.ready == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ grouped by version, with the most recent changes first.
 
 ### Fixed
 
+- Updated the Firefox development toolchain to the patched `shell-quote`
+  release and kept future development-only advisories visible without blocking
+  daily live-verification proposals; complete dependency audits remain required
+  by normal pull-request CI.
 - Replaced production-shaped conversation labels and identifiers in Messenger
   regression fixtures with clearly synthetic values.
 - Separated the published verification target from the repository version so

--- a/package-lock.json
+++ b/package-lock.json
@@ -3799,9 +3799,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.9.0.tgz",
+      "integrity": "sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -26,10 +26,13 @@
     "validate:tag-integrity": "node scripts/validate-version-tag-integrity.js",
     "lint:firefox": "npm run prepare:firefox && web-ext lint --source-dir tmp/firefox-extension --warnings-as-errors",
     "verify:dist": "git diff --exit-code -- dist/background.js dist/js/content.js dist/js/ghost.js dist/js/messenger_patch.js",
+    "audit:runtime": "npm audit --omit=dev --audit-level=high",
     "audit:high": "npm audit --audit-level=high",
     "ci:chromium": "npm run build && npm run test:modules:shared && npm run test:popup:chromium && node test/messenger-send-stability.test.js && npm run test:status && npm run test:release-notes && npm run test:tag-integrity && npm run test:validator && npm run test:package:chromium && npm run validate:extension && npm run validate:tag-integrity && npm run verify:dist && npm run audit:high",
     "ci:firefox": "npm run build && npm run test:modules:shared && npm run test:popup:firefox && node test/messenger-send-stability.test.js && npm run test:package:firefox && npm run validate:firefox && npm run lint:firefox && npm run verify:dist && npm run audit:high",
-    "ci": "npm test && npm run validate:extension && npm run validate:firefox && npm run validate:tag-integrity && npm run lint:firefox && npm run verify:dist && npm run audit:high"
+    "ci:all-browsers": "npm test && npm run validate:extension && npm run validate:firefox && npm run validate:tag-integrity && npm run lint:firefox && npm run verify:dist",
+    "ci:verification": "npm run ci:all-browsers && npm run audit:runtime",
+    "ci": "npm run ci:all-browsers && npm run audit:high"
   },
   "repository": {
     "type": "git",
@@ -50,6 +53,7 @@
     "node": ">=22.13"
   },
   "overrides": {
+    "shell-quote": "1.9.0",
     "firefox-profile@4.7.0": {
       "adm-zip": "0.6.0"
     }

--- a/test/daily-verification-git.test.js
+++ b/test/daily-verification-git.test.js
@@ -5,9 +5,29 @@ const os = require('os');
 const path = require('path');
 
 const workflow = fs.readFileSync('.github/workflows/daily-verification.yml', 'utf8');
+const packageJson = JSON.parse(fs.readFileSync('package.json', 'utf8'));
 assert(
     workflow.includes('I tested the extension installed from the Chrome Web Store, not an unpacked development build.'),
     'daily verification PRs must identify the tested Store-installed artifact'
+);
+assert(
+    workflow.includes('run: npm run ci:verification'),
+    'daily verification must use the release-runtime audit boundary'
+);
+assert(
+    workflow.includes('id: tooling-audit') &&
+        workflow.includes('continue-on-error: true') &&
+        workflow.includes("steps.tooling-audit.outcome == 'failure'"),
+    'daily verification must report development-tool advisories without blocking live-status proposals'
+);
+assert(
+    packageJson.scripts['audit:runtime'].includes('--omit=dev') &&
+        packageJson.scripts['ci:verification'].includes('audit:runtime'),
+    'daily verification CI must keep runtime advisories blocking'
+);
+assert(
+    packageJson.scripts.ci.includes('audit:high'),
+    'normal CI must keep the complete dependency audit blocking'
 );
 
 function git(cwd, args, options = {}) {


### PR DESCRIPTION
## What changed

- override the Firefox tooling dependency `shell-quote` to patched version 1.9.0
- keep complete dependency audits blocking in normal pull-request CI
- give the daily live-verification workflow a separate blocking runtime audit
- report development-tool advisories in the scheduled run without preventing the verification proposal
- add regression checks for the audit boundary

## Root cause

GitHub added GHSA-395f-4hp3-45gv to its advisory database. `web-ext@10.5.0` currently pins `fx-runner@1.5.0`, which pins vulnerable `shell-quote@1.8.4`. The resulting high-severity npm audit finding stopped the scheduled workflow before it could create the daily verification PR.

## Impact

The vulnerable package is development-only and is not shipped in the Ghostify extension runtime. The patched override removes the current finding. Future development-tool advisories remain visible and still block ordinary pull-request CI, while they no longer suppress a manual live-verification proposal. Runtime advisories remain blocking in the daily workflow.

## Validation

- `npm ci`
- `npm run ci`
- `npm audit --audit-level=high`
- `npm audit --omit=dev --audit-level=high`
- `npm ls shell-quote` resolves `shell-quote@1.9.0 overridden`
- `git diff --check`
