### PR TITLE
fix(ci): Approve daily pull request checks

### DIFF
--- a/.github/workflows/daily-verification.yml
+++ b/.github/workflows/daily-verification.yml
@@ -312,7 +312,7 @@ jobs:
             gh pr create --base main --head "$BRANCH" --title "$TITLE" --body-file "$RUNNER_TEMP/pr-body.md"
           fi
 
-      - name: Dispatch required CI for the proposal commit
+      - name: Approve required pull-request CI for the proposal commit
         if: needs.validate-proposal.outputs.ready == 'true'
         shell: bash
         env:
@@ -320,14 +320,14 @@ jobs:
           HEAD_SHA: ${{ steps.publish-branch.outputs.head_sha }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh workflow run ci.yml --ref "$BRANCH"
           for _ in {1..10}; do
-            run_url="$(gh run list --workflow ci.yml --branch "$BRANCH" --event workflow_dispatch --limit 20 --json headSha,url --jq ".[] | select(.headSha == \"$HEAD_SHA\") | .url" | head -n 1)"
-            if [[ -n "$run_url" ]]; then
-              echo "Required CI dispatched for $HEAD_SHA: $run_url" >> "$GITHUB_STEP_SUMMARY"
+            run_id="$(gh run list --workflow ci.yml --branch "$BRANCH" --event pull_request --limit 20 --json databaseId,headSha,conclusion --jq ".[] | select(.headSha == \"$HEAD_SHA\" and .conclusion == \"action_required\") | .databaseId" | head -n 1)"
+            if [[ -n "$run_id" ]]; then
+              gh api --method POST "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/approve"
+              echo "Required pull-request CI approved for $HEAD_SHA: https://github.com/${GITHUB_REPOSITORY}/actions/runs/${run_id}" >> "$GITHUB_STEP_SUMMARY"
               exit 0
             fi
             sleep 3
           done
-          echo "Required CI was not found for proposal commit $HEAD_SHA." >&2
+          echo "Approval-required pull-request CI was not found for proposal commit $HEAD_SHA." >&2
           exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ grouped by version, with the most recent changes first.
 
 - Split daily status validation from proposal publishing so third-party build
   dependencies run with read-only repository access, and bot-created proposals
-  explicitly receive required CI for their exact commit.
+  explicitly approve required pull-request CI for their exact commit.
 - Advanced the repository package identity to `2.0.6` so changes made after
   the published `2.0.5` tag cannot produce a second, different `2.0.5` ZIP.
 - Replaced the legacy persisted configuration path with packaged,

--- a/test/daily-verification-git.test.js
+++ b/test/daily-verification-git.test.js
@@ -54,10 +54,11 @@ assert(
     'the write-enabled publishing job must not install package dependencies'
 );
 assert(
-        publishJob.includes('echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"') &&
-        publishJob.includes('gh workflow run ci.yml --ref "$BRANCH"') &&
-        publishJob.includes('select(.headSha == \\"$HEAD_SHA\\")'),
-    'bot-created proposals must dispatch required CI and verify the exact proposal commit'
+    publishJob.includes('echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"') &&
+        publishJob.includes('--event pull_request') &&
+        publishJob.includes('select(.headSha == \\"$HEAD_SHA\\" and .conclusion == \\"action_required\\")') &&
+        publishJob.includes('actions/runs/${run_id}/approve'),
+    'bot-created proposals must approve required pull-request CI for the exact proposal commit'
 );
 assert.deepStrictEqual(
     packageJson.overrides['fx-runner@1.5.0'],


### PR DESCRIPTION
## Summary

- approve the exact approval-required pull-request CI run created for a bot-authored daily proposal
- stop relying on workflow-dispatch checks, which GitHub does not include in the pull request's required-check rollup
- retain the exact-head-SHA guard and narrow Actions write permission

## Validation

- node test/daily-verification-git.test.js
- npm run ci
- actionlint 1.7.12
- live GitHub confirmation: approving the pull_request run makes PR #101 CLEAN