### PR TITLE
fix(facebook): Preserve queue-routed group message sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ section, and GitHub Releases should match the facts recorded here.
 The format follows the spirit of Keep a Changelog: human-written entries,
 grouped by version, with the most recent changes first.
 
-## [2.0.6] - Unreleased
+## [2.0.6] - 2026-07-22
 
 ### Added
 
@@ -39,6 +39,9 @@ grouped by version, with the most recent changes first.
 
 ### Fixed
 
+- Preserved queue-routed Facebook group-message sends while removing bundled
+  typing and Seen metadata, preventing affected messages from remaining stuck
+  in the Sending state.
 - Updated the Firefox development toolchain to the patched `shell-quote`
   release. Complete dependency reviews remain visible on daily proposals,
   website runtime advisories block proposal creation, and required pull-request

--- a/dist/js/messenger_patch.js
+++ b/dist/js/messenger_patch.js
@@ -1342,6 +1342,7 @@
       const wrapped = function(message, transfer) {
         const needsInspection = isPostMessageObservationEnabled() || window.__ghostify_shouldBlockTyping() || window.__ghostify_shouldBlockMessengerSeen();
         const text = needsInspection ? stringifyForMatch(message).toLowerCase() : "";
+        const hasQueueRoutedSendTask = needsInspection && containsQueueRoutedMessengerSendTask(message);
         if (hasNativeMessageRequestBypass() && isMessageRequestHydrationText(text)) {
           return originalPostMessage.apply(this, arguments);
         }
@@ -1388,6 +1389,11 @@
                 tracePostMessageOutcome(kind, blockType, "sanitize_typing", message, text);
                 return forwardSanitizedPostMessage(originalPostMessage, this, sanitizedTyping.value, transferSafe);
               }
+            }
+            if (hasQueueRoutedSendTask) {
+              window.__GHOSTIFY_FACEBOOK_UNSAFE_BLOCKS_SKIPPED__ = (window.__GHOSTIFY_FACEBOOK_UNSAFE_BLOCKS_SKIPPED__ || 0) + 1;
+              tracePostMessageOutcome(kind, blockType, "queue_send_forward", message, text);
+              return originalPostMessage.apply(this, arguments);
             }
             if (isSafeFacebookBridgeBlock(blockType, text)) {
               window.__GHOSTIFY_BLOCKED_WORKER_MESSAGES__ = (window.__GHOSTIFY_BLOCKED_WORKER_MESSAGES__ || 0) + 1;
@@ -1533,7 +1539,8 @@
         const next = [];
         for (const item of value) {
           const itemText = stringifyForMatch(item).toLowerCase();
-          if (depth > 0 && isDedicatedServerReadReceiptCommand(itemText)) {
+          const isSendItem = isBridgeSendItemObject(item, itemText);
+          if (!isSendItem && depth > 0 && isDedicatedServerReadReceiptCommand(itemText)) {
             changed = true;
             continue;
           }
@@ -1547,7 +1554,7 @@
             next.push(sanitizedItem.value);
             continue;
           }
-          if (isDedicatedServerReadReceiptCommand(itemText)) {
+          if (!isSendItem && isDedicatedServerReadReceiptCommand(itemText)) {
             changed = true;
             continue;
           }
@@ -1561,6 +1568,9 @@
       }
       if (typeof value === "object") {
         const ownText = stringifyForMatch(value).toLowerCase();
+        if (isQueueRoutedMessengerSendTask(value)) {
+          return sanitizeQueueRoutedSendReadMetadata(value);
+        }
         if (isBridgeSendItemObject(value, ownText)) {
           return { value, changed: false, blockedAll: false };
         }
@@ -1605,7 +1615,7 @@
             blockedAll: isBridgeEnvelopeMetadataOnly(clone)
           };
         }
-        if (isDedicatedServerReadReceiptCommand(ownText)) {
+        if (!containsQueueRoutedMessengerSendTask(value) && isDedicatedServerReadReceiptCommand(ownText)) {
           return { value: void 0, changed: true, blockedAll: true };
         }
       }
@@ -1708,6 +1718,143 @@
       if (hasSendOperationName && (hasMessagePayload || hasClientMessageId || matchText.includes("send_type"))) return true;
       return matchText.includes("send_type") && hasClientMessageId && hasMessagePayload;
     }
+    function containsQueueRoutedMessengerSendTask(value, depth = 0) {
+      if (!value || depth > 6 || isBinaryPayload(value)) return false;
+      if (Array.isArray(value)) {
+        return value.some((item) => containsQueueRoutedMessengerSendTask(item, depth + 1));
+      }
+      if (typeof value === "string") {
+        const trimmed = value.trim();
+        if (!trimmed || trimmed[0] !== "{" && trimmed[0] !== "[") return false;
+        try {
+          return containsQueueRoutedMessengerSendTask(JSON.parse(trimmed), depth + 1);
+        } catch (e) {
+          return false;
+        }
+      }
+      if (typeof value !== "object") return false;
+      if (isQueueRoutedMessengerSendTask(value)) return true;
+      try {
+        return Object.keys(value).some(
+          (key) => containsQueueRoutedMessengerSendTask(value[key], depth + 1)
+        );
+      } catch (e) {
+        return false;
+      }
+    }
+    function isQueueRoutedMessengerSendTask(value) {
+      if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+      const fields = normalizedBridgeFields(value);
+      if (String(fields.label || "") !== "46") return false;
+      if (typeof fields.queuename !== "string" || !fields.queuename.trim()) return false;
+      const payload = parseBridgeObject(fields.payload);
+      if (!payload) return false;
+      const payloadFields = normalizedBridgeFields(payload);
+      const sendType = payloadFields.sendtype;
+      if (!(typeof sendType === "number" && Number.isFinite(sendType) && sendType > 0)) return false;
+      const hasClientMessageId = [
+        "offlinethreadingid",
+        "clientmessageid",
+        "clientmutationid",
+        "otid"
+      ].some((key) => payloadFields[key] != null && String(payloadFields[key]).length > 0);
+      const hasMessagePayload = [
+        "message",
+        "text",
+        "body",
+        "attachment",
+        "sticker",
+        "media",
+        "encryptedmessage",
+        "encryptedpayload",
+        "encryptedblob",
+        "encryptedcontent",
+        "ciphertext",
+        "reaction",
+        "messagereaction",
+        "emoji",
+        "quicklike"
+      ].some((key) => payloadFields[key] != null);
+      return hasClientMessageId && hasMessagePayload;
+    }
+    function normalizedBridgeFields(value) {
+      const fields = {};
+      try {
+        for (const key of Object.keys(value)) {
+          fields[normalizeBridgeKey(key)] = value[key];
+        }
+      } catch (e) {
+      }
+      return fields;
+    }
+    function parseBridgeObject(value) {
+      if (value && typeof value === "object" && !Array.isArray(value)) return value;
+      if (typeof value !== "string") return null;
+      try {
+        const parsed = JSON.parse(value);
+        return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+      } catch (e) {
+        return null;
+      }
+    }
+    function sanitizeQueueRoutedSendReadMetadata(task) {
+      let payloadKey;
+      try {
+        payloadKey = Object.keys(task).find((key) => normalizeBridgeKey(key) === "payload");
+      } catch (e) {
+        return { value: task, changed: false, blockedAll: false };
+      }
+      if (!payloadKey) return { value: task, changed: false, blockedAll: false };
+      const rawPayload = task[payloadKey];
+      const payload = parseBridgeObject(rawPayload);
+      if (!payload) return { value: task, changed: false, blockedAll: false };
+      const sanitized = sanitizeQueueSendPayloadReadMetadata(payload);
+      if (!sanitized.changed) return { value: task, changed: false, blockedAll: false };
+      const clone = Object.assign({}, task);
+      clone[payloadKey] = typeof rawPayload === "string" ? JSON.stringify(sanitized.value) : sanitized.value;
+      return { value: clone, changed: true, blockedAll: false };
+    }
+    function sanitizeQueueSendPayloadReadMetadata(value, depth = 0) {
+      if (!value || depth > 6 || typeof value !== "object" || isBinaryPayload(value)) {
+        return { value, changed: false };
+      }
+      if (Array.isArray(value)) {
+        let changed2 = false;
+        const next = value.map((item) => {
+          const sanitized = sanitizeQueueSendPayloadReadMetadata(item, depth + 1);
+          changed2 = changed2 || sanitized.changed;
+          return sanitized.value;
+        });
+        return { value: changed2 ? next : value, changed: changed2 };
+      }
+      let changed = false;
+      const clone = {};
+      for (const key of Object.keys(value)) {
+        const child = value[key];
+        const normalizedKey = normalizeBridgeKey(key);
+        if (isReadReceiptSendFlagKey(normalizedKey)) {
+          const truthy = isTruthyPrivacyValue(child);
+          clone[key] = truthy ? false : child;
+          changed = changed || truthy;
+          continue;
+        }
+        if (isReadReceiptMutationKey(normalizedKey)) {
+          const truthy = isTruthyPrivacyValue(child);
+          clone[key] = truthy ? null : child;
+          changed = changed || truthy;
+          continue;
+        }
+        if (isReadWatermarkKey(normalizedKey) && isLikelyReadWatermarkValue(child)) {
+          clone[key] = safeReadWatermarkValue(child);
+          changed = changed || clone[key] !== child;
+          continue;
+        }
+        const sanitized = sanitizeQueueSendPayloadReadMetadata(child, depth + 1);
+        clone[key] = sanitized.value;
+        changed = changed || sanitized.changed;
+      }
+      return { value: changed ? clone : value, changed };
+    }
     function tracePostMessageOutcome(kind, blockType, outcome, message, text) {
       if (!isPostMessageObservationEnabled() && !String(outcome || "").startsWith("drop")) return;
       const haystack = String(text || "").toLowerCase();
@@ -1751,7 +1898,8 @@
         const next = [];
         for (const item of value) {
           const itemText = stringifyForMatch(item).toLowerCase();
-          if (!hasMessengerMessageSendIntentText(itemText) && (shouldBlockTypingText(itemText) || shouldBlockSeenText(itemText))) {
+          const isSendItem = isBridgeSendItemObject(item, itemText);
+          if (!isSendItem && (shouldBlockTypingText(itemText) || shouldBlockSeenText(itemText))) {
             changed = true;
             continue;
           }
@@ -1761,7 +1909,7 @@
             continue;
           }
           if (!sanitizedItem.changed) {
-            if (!hasMessengerMessageSendIntentText(itemText) && (shouldBlockTypingText(itemText) || shouldBlockSeenText(itemText))) {
+            if (!isSendItem && (shouldBlockTypingText(itemText) || shouldBlockSeenText(itemText))) {
               changed = true;
               continue;
             }
@@ -1777,6 +1925,9 @@
       }
       if (typeof value === "object") {
         const ownText = stringifyForMatch(value).toLowerCase();
+        if (isQueueRoutedMessengerSendTask(value)) {
+          return sanitizeQueueRoutedSendReadMetadata(value);
+        }
         if (isBridgeSendItemObject(value, ownText)) {
           return { value, changed: false, blockedAll: false };
         }
@@ -1787,7 +1938,8 @@
           const child = value[key];
           if (child && typeof child === "object" && !isBinaryPayload(child)) {
             const childText = stringifyForMatch(child).toLowerCase();
-            if (!hasMessengerMessageSendIntentText(childText) && (shouldBlockTypingText(childText) || shouldBlockSeenText(childText))) {
+            const childContainsSend = containsQueueRoutedMessengerSendTask(child);
+            if (!childContainsSend && !hasMessengerMessageSendIntentText(childText) && (shouldBlockTypingText(childText) || shouldBlockSeenText(childText))) {
               changed = true;
               continue;
             }
@@ -1820,7 +1972,7 @@
     }
     function isBridgeSendItemObject(value, text) {
       if (!value || typeof value !== "object" || Array.isArray(value)) return false;
-      if (!hasMessengerMessageSendIntentText(text)) return false;
+      if (!isQueueRoutedMessengerSendTask(value) && !hasMessengerMessageSendIntentText(text)) return false;
       const keys = Object.keys(value).map(normalizeBridgeKey);
       if (keys.includes("tasks") || keys.includes("tasklist") || keys.includes("batch")) return false;
       return keys.some((key) => [

--- a/src/messenger_patch.js
+++ b/src/messenger_patch.js
@@ -1306,6 +1306,7 @@ import {
                 window.__ghostify_shouldBlockTyping() ||
                 window.__ghostify_shouldBlockMessengerSeen();
             const text = needsInspection ? stringifyForMatch(message).toLowerCase() : '';
+            const hasQueueRoutedSendTask = needsInspection && containsQueueRoutedMessengerSendTask(message);
             if (hasNativeMessageRequestBypass() && isMessageRequestHydrationText(text)) {
                 return originalPostMessage.apply(this, arguments);
             }
@@ -1360,6 +1361,12 @@ import {
                             tracePostMessageOutcome(kind, blockType, 'sanitize_typing', message, text);
                             return forwardSanitizedPostMessage(originalPostMessage, this, sanitizedTyping.value, transferSafe);
                         }
+                    }
+
+                    if (hasQueueRoutedSendTask) {
+                        window.__GHOSTIFY_FACEBOOK_UNSAFE_BLOCKS_SKIPPED__ = (window.__GHOSTIFY_FACEBOOK_UNSAFE_BLOCKS_SKIPPED__ || 0) + 1;
+                        tracePostMessageOutcome(kind, blockType, 'queue_send_forward', message, text);
+                        return originalPostMessage.apply(this, arguments);
                     }
 
                     if (isSafeFacebookBridgeBlock(blockType, text)) {
@@ -1553,7 +1560,8 @@ import {
 
             for (const item of value) {
                 const itemText = stringifyForMatch(item).toLowerCase();
-                if (depth > 0 && isDedicatedServerReadReceiptCommand(itemText)) {
+                const isSendItem = isBridgeSendItemObject(item, itemText);
+                if (!isSendItem && depth > 0 && isDedicatedServerReadReceiptCommand(itemText)) {
                     changed = true;
                     continue;
                 }
@@ -1570,7 +1578,7 @@ import {
                     continue;
                 }
 
-                if (isDedicatedServerReadReceiptCommand(itemText)) {
+                if (!isSendItem && isDedicatedServerReadReceiptCommand(itemText)) {
                     changed = true;
                     continue;
                 }
@@ -1587,6 +1595,9 @@ import {
 
         if (typeof value === 'object') {
             const ownText = stringifyForMatch(value).toLowerCase();
+            if (isQueueRoutedMessengerSendTask(value)) {
+                return sanitizeQueueRoutedSendReadMetadata(value);
+            }
             if (isBridgeSendItemObject(value, ownText)) {
                 return { value, changed: false, blockedAll: false };
             }
@@ -1639,7 +1650,7 @@ import {
                 };
             }
 
-            if (isDedicatedServerReadReceiptCommand(ownText)) {
+            if (!containsQueueRoutedMessengerSendTask(value) && isDedicatedServerReadReceiptCommand(ownText)) {
                 return { value: undefined, changed: true, blockedAll: true };
             }
         }
@@ -1780,6 +1791,159 @@ import {
         return matchText.includes('send_type') && hasClientMessageId && hasMessagePayload;
     }
 
+    function containsQueueRoutedMessengerSendTask(value, depth = 0) {
+        if (!value || depth > 6 || isBinaryPayload(value)) return false;
+        if (Array.isArray(value)) {
+            return value.some(item => containsQueueRoutedMessengerSendTask(item, depth + 1));
+        }
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (!trimmed || (trimmed[0] !== '{' && trimmed[0] !== '[')) return false;
+            try {
+                return containsQueueRoutedMessengerSendTask(JSON.parse(trimmed), depth + 1);
+            } catch (e) {
+                return false;
+            }
+        }
+        if (typeof value !== 'object') return false;
+        if (isQueueRoutedMessengerSendTask(value)) return true;
+
+        try {
+            return Object.keys(value).some(key =>
+                containsQueueRoutedMessengerSendTask(value[key], depth + 1)
+            );
+        } catch (e) {
+            return false;
+        }
+    }
+
+    function isQueueRoutedMessengerSendTask(value) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+        const fields = normalizedBridgeFields(value);
+        if (String(fields.label || '') !== '46') return false;
+        if (typeof fields.queuename !== 'string' || !fields.queuename.trim()) return false;
+
+        const payload = parseBridgeObject(fields.payload);
+        if (!payload) return false;
+        const payloadFields = normalizedBridgeFields(payload);
+        const sendType = payloadFields.sendtype;
+        if (!(typeof sendType === 'number' && Number.isFinite(sendType) && sendType > 0)) return false;
+
+        const hasClientMessageId = [
+            'offlinethreadingid',
+            'clientmessageid',
+            'clientmutationid',
+            'otid'
+        ].some(key => payloadFields[key] != null && String(payloadFields[key]).length > 0);
+        const hasMessagePayload = [
+            'message',
+            'text',
+            'body',
+            'attachment',
+            'sticker',
+            'media',
+            'encryptedmessage',
+            'encryptedpayload',
+            'encryptedblob',
+            'encryptedcontent',
+            'ciphertext',
+            'reaction',
+            'messagereaction',
+            'emoji',
+            'quicklike'
+        ].some(key => payloadFields[key] != null);
+
+        return hasClientMessageId && hasMessagePayload;
+    }
+
+    function normalizedBridgeFields(value) {
+        const fields = {};
+        try {
+            for (const key of Object.keys(value)) {
+                fields[normalizeBridgeKey(key)] = value[key];
+            }
+        } catch (e) { }
+        return fields;
+    }
+
+    function parseBridgeObject(value) {
+        if (value && typeof value === 'object' && !Array.isArray(value)) return value;
+        if (typeof value !== 'string') return null;
+        try {
+            const parsed = JSON.parse(value);
+            return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function sanitizeQueueRoutedSendReadMetadata(task) {
+        let payloadKey;
+        try {
+            payloadKey = Object.keys(task).find(key => normalizeBridgeKey(key) === 'payload');
+        } catch (e) {
+            return { value: task, changed: false, blockedAll: false };
+        }
+        if (!payloadKey) return { value: task, changed: false, blockedAll: false };
+
+        const rawPayload = task[payloadKey];
+        const payload = parseBridgeObject(rawPayload);
+        if (!payload) return { value: task, changed: false, blockedAll: false };
+
+        const sanitized = sanitizeQueueSendPayloadReadMetadata(payload);
+        if (!sanitized.changed) return { value: task, changed: false, blockedAll: false };
+
+        const clone = Object.assign({}, task);
+        clone[payloadKey] = typeof rawPayload === 'string'
+            ? JSON.stringify(sanitized.value)
+            : sanitized.value;
+        return { value: clone, changed: true, blockedAll: false };
+    }
+
+    function sanitizeQueueSendPayloadReadMetadata(value, depth = 0) {
+        if (!value || depth > 6 || typeof value !== 'object' || isBinaryPayload(value)) {
+            return { value, changed: false };
+        }
+        if (Array.isArray(value)) {
+            let changed = false;
+            const next = value.map(item => {
+                const sanitized = sanitizeQueueSendPayloadReadMetadata(item, depth + 1);
+                changed = changed || sanitized.changed;
+                return sanitized.value;
+            });
+            return { value: changed ? next : value, changed };
+        }
+
+        let changed = false;
+        const clone = {};
+        for (const key of Object.keys(value)) {
+            const child = value[key];
+            const normalizedKey = normalizeBridgeKey(key);
+            if (isReadReceiptSendFlagKey(normalizedKey)) {
+                const truthy = isTruthyPrivacyValue(child);
+                clone[key] = truthy ? false : child;
+                changed = changed || truthy;
+                continue;
+            }
+            if (isReadReceiptMutationKey(normalizedKey)) {
+                const truthy = isTruthyPrivacyValue(child);
+                clone[key] = truthy ? null : child;
+                changed = changed || truthy;
+                continue;
+            }
+            if (isReadWatermarkKey(normalizedKey) && isLikelyReadWatermarkValue(child)) {
+                clone[key] = safeReadWatermarkValue(child);
+                changed = changed || clone[key] !== child;
+                continue;
+            }
+
+            const sanitized = sanitizeQueueSendPayloadReadMetadata(child, depth + 1);
+            clone[key] = sanitized.value;
+            changed = changed || sanitized.changed;
+        }
+        return { value: changed ? clone : value, changed };
+    }
+
     function tracePostMessageOutcome(kind, blockType, outcome, message, text) {
         if (!isPostMessageObservationEnabled() && !String(outcome || '').startsWith('drop')) return;
         const haystack = String(text || '').toLowerCase();
@@ -1831,7 +1995,8 @@ import {
 
             for (const item of value) {
                 const itemText = stringifyForMatch(item).toLowerCase();
-                if (!hasMessengerMessageSendIntentText(itemText) && (shouldBlockTypingText(itemText) || shouldBlockSeenText(itemText))) {
+                const isSendItem = isBridgeSendItemObject(item, itemText);
+                if (!isSendItem && (shouldBlockTypingText(itemText) || shouldBlockSeenText(itemText))) {
                     changed = true;
                     continue;
                 }
@@ -1843,7 +2008,7 @@ import {
                 }
 
                 if (!sanitizedItem.changed) {
-                    if (!hasMessengerMessageSendIntentText(itemText) && (shouldBlockTypingText(itemText) || shouldBlockSeenText(itemText))) {
+                    if (!isSendItem && (shouldBlockTypingText(itemText) || shouldBlockSeenText(itemText))) {
                         changed = true;
                         continue;
                     }
@@ -1862,6 +2027,9 @@ import {
 
         if (typeof value === 'object') {
             const ownText = stringifyForMatch(value).toLowerCase();
+            if (isQueueRoutedMessengerSendTask(value)) {
+                return sanitizeQueueRoutedSendReadMetadata(value);
+            }
             if (isBridgeSendItemObject(value, ownText)) {
                 return { value, changed: false, blockedAll: false };
             }
@@ -1874,7 +2042,10 @@ import {
                 const child = value[key];
                 if (child && typeof child === 'object' && !isBinaryPayload(child)) {
                     const childText = stringifyForMatch(child).toLowerCase();
-                    if (!hasMessengerMessageSendIntentText(childText) && (shouldBlockTypingText(childText) || shouldBlockSeenText(childText))) {
+                    const childContainsSend = containsQueueRoutedMessengerSendTask(child);
+                    if (!childContainsSend &&
+                        !hasMessengerMessageSendIntentText(childText) &&
+                        (shouldBlockTypingText(childText) || shouldBlockSeenText(childText))) {
                         changed = true;
                         continue;
                     }
@@ -1912,7 +2083,7 @@ import {
 
     function isBridgeSendItemObject(value, text) {
         if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
-        if (!hasMessengerMessageSendIntentText(text)) return false;
+        if (!isQueueRoutedMessengerSendTask(value) && !hasMessengerMessageSendIntentText(text)) return false;
 
         const keys = Object.keys(value).map(normalizeBridgeKey);
         if (keys.includes('tasks') || keys.includes('tasklist') || keys.includes('batch')) return false;

--- a/test/messenger-send-stability.test.js
+++ b/test/messenger-send-stability.test.js
@@ -1569,6 +1569,148 @@ function testFacebookMiniChatMixedSendTypingBridgeFrameDoesNotEnterTypingSanitiz
     assert.strictEqual(forwarded.tasks[1].label, 'sendChatStateFromComposer');
 }
 
+function testFacebookGroupSendWithQueueOnlyTargetPreservesSendAndRemovesTyping() {
+    const context = makeMessengerPatchPage({}, {
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/',
+        facebookMiniChatOpen: true
+    });
+    const message = {
+        issue_new_task: true,
+        tasks: [{
+            label: '46',
+            queue_name: 'redacted-group-thread',
+            task_id: 414,
+            payload: JSON.stringify({
+                offline_threading_id: 'redacted-offline-id',
+                send_type: 1,
+                message: { text: 'group message' },
+                sync_group: 104
+            })
+        }, {
+            label: 'sendChatStateFromComposer',
+            queue_name: 'redacted-group-thread',
+            task_id: 415,
+            payload: JSON.stringify({
+                chatstate: 'typing_indicator',
+                send_type: 'typing'
+            })
+        }]
+    };
+    const outcome = workerOutcome(context, message);
+
+    assert.strictEqual(outcome.result, 'worker-sent');
+    assert.strictEqual(outcome.postCount, 1);
+    assert.strictEqual(outcome.blocked, 0);
+    assert.strictEqual(
+        outcome.sanitized,
+        1,
+        'Facebook group sends routed only by queue_name must remove bundled typing without dropping the send'
+    );
+    assert.notStrictEqual(outcome.post.message, message);
+    assert.strictEqual(outcome.post.message.tasks.length, 1);
+    assert.strictEqual(outcome.post.message.tasks[0], message.tasks[0]);
+
+    const seenContext = makeMessengerPatchPage({}, {
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/',
+        facebookMiniChatOpen: true
+    });
+    const seenMessage = {
+        issue_new_task: true,
+        tasks: [{
+            label: '46',
+            queue_name: 'redacted-group-thread',
+            task_id: 416,
+            payload: JSON.stringify({
+                offline_threading_id: 'redacted-offline-id',
+                send_type: 1,
+                message: { text: 'group message' },
+                sync_group: 104,
+                last_read_watermark_ts: 1779530000000,
+                should_send_read_receipt: true
+            })
+        }]
+    };
+    const seenOutcome = workerOutcome(seenContext, seenMessage);
+
+    assert.strictEqual(seenOutcome.result, 'worker-sent');
+    assert.strictEqual(seenOutcome.postCount, 1);
+    assert.strictEqual(seenOutcome.blocked, 0);
+    assert.strictEqual(
+        seenOutcome.sanitizedSeen,
+        1,
+        'queue-only Facebook group sends must remove bundled Seen metadata without dropping the send'
+    );
+    assert.notStrictEqual(seenOutcome.post.message, seenMessage);
+    assert.strictEqual(seenOutcome.post.message.tasks.length, 1);
+    assert.strictEqual(seenOutcome.post.message.tasks[0].label, '46');
+    assert.strictEqual(seenOutcome.post.message.tasks[0].queue_name, 'redacted-group-thread');
+    assert.strictEqual(seenOutcome.post.message.tasks[0].task_id, 416);
+    const sanitizedSendPayload = JSON.parse(seenOutcome.post.message.tasks[0].payload);
+    assert.strictEqual(sanitizedSendPayload.message.text, 'group message');
+    assert.strictEqual(sanitizedSendPayload.offline_threading_id, 'redacted-offline-id');
+    assert.strictEqual(sanitizedSendPayload.should_send_read_receipt, false);
+    assert.strictEqual(sanitizedSendPayload.last_read_watermark_ts, SAFE_READ_WATERMARK);
+}
+
+function testFacebookQueueOnlyPrivacyTasksAreNotClassifiedAsSends() {
+    const typingContext = makeMessengerPatchPage({}, {
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/',
+        facebookMiniChatOpen: true
+    });
+    const typingTask = {
+        issue_new_task: true,
+        tasks: [{
+            label: 'sendChatStateFromComposer',
+            queue_name: 'redacted-group-thread',
+            task_id: 417,
+            payload: JSON.stringify({
+                offline_threading_id: 'redacted-offline-id',
+                send_type: 'typing',
+                message: { text: 'incidental metadata' },
+                chatstate: 'typing_indicator'
+            })
+        }]
+    };
+    const typingOutcome = workerOutcome(typingContext, typingTask);
+
+    assert.strictEqual(typingOutcome.result, undefined);
+    assert.strictEqual(typingOutcome.postCount, 0);
+    assert.strictEqual(typingOutcome.blocked, 1);
+
+    const seenContext = makeMessengerPatchPage({}, {
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/',
+        facebookMiniChatOpen: true
+    });
+    const seenTask = {
+        issue_new_task: true,
+        tasks: [{
+            label: 'markThreadAsRead',
+            queue_name: 'redacted-group-thread',
+            task_id: 418,
+            payload: JSON.stringify({
+                offline_threading_id: 'redacted-offline-id',
+                send_type: 1,
+                message: { text: 'incidental metadata' },
+                last_read_watermark_ts: 1779530000000,
+                should_send_read_receipt: true
+            })
+        }]
+    };
+    const seenOutcome = workerOutcome(seenContext, seenTask);
+
+    assert.strictEqual(seenOutcome.result, undefined);
+    assert.strictEqual(seenOutcome.postCount, 0);
+    assert.strictEqual(seenOutcome.blocked, 1);
+}
+
 async function testFacebookSecureEncryptedDirectRecipientSendsAreAllowed() {
     const facebookWindow = makeGhostPage({
         hostname: 'www.facebook.com',
@@ -8643,6 +8785,8 @@ async function testMessageRequestClickGraceKeepsTransportAndBridgeNative() {
     testFacebookPatchMixedSendTypingBatchPreservesSend();
     testFacebookMiniChatSecureSendWithAlternateTargetsIsForwarded();
     testFacebookMiniChatMixedSendTypingBridgeFrameDoesNotEnterTypingSanitizer();
+    testFacebookGroupSendWithQueueOnlyTargetPreservesSendAndRemovesTyping();
+    testFacebookQueueOnlyPrivacyTasksAreNotClassifiedAsSends();
     await testFacebookSecureEncryptedDirectRecipientSendsAreAllowed();
     testMessengerPatchMixedSendReadStringBatchPreservesSend();
     testMessengerPatchObjectMapBatchSanitizesPrivacyTasks();


### PR DESCRIPTION
## Summary

- preserve queue-routed Messenger group-message send tasks identified by the structured label-46 payload
- remove bundled typing and Seen metadata without dropping the actual message send
- add regression coverage for queue-only group sends and privacy-only lookalikes
- rebuild the generated Messenger patch bundle

## Root cause

Some Facebook group sends are routed with `queue_name` and a label-46 task but without the operation-name signals used by the existing send classifier. Privacy sanitization could therefore treat the batch as privacy-only and prevent the real message task from reaching Messenger.

## Impact

Group messages continue sending normally while Hide Typing and Hide Seen remain applied to bundled privacy metadata.

## Validation

- `npm test`
- `git diff --check`
- live send checks in the affected BAG-EO group and the comparison Pizza group on Messenger and Facebook mini-chat
- independent runtime/privacy and regression/artifact reviews

Related to #106.