### PR TITLE
fix(status): mark July 21 report as known issue

### DIFF
--- a/site/src/app/statusData.json
+++ b/site/src/app/statusData.json
@@ -189,8 +189,8 @@
     },
     {
       "date": "2026-07-21",
-      "publicStatus": "under_review",
-      "eventType": "investigation",
+      "publicStatus": "known_issue",
+      "eventType": "incident",
       "title": "Facebook group-message sending report acknowledged",
       "summary": "A report that messages in some Facebook group chats could remain stuck in Sending was reproduced and investigated."
     },


### PR DESCRIPTION
## Summary

- classify the July 21 Facebook group-message report as a known issue/incident
- preserve the July 22 v2.0.6 published and verification-in-progress records
- keep the July 22 status-calendar square green through its product-update marker

Related to #106.

## Validation

- `npm run test:status`
- `npm run build` in `site/`
- `npm run ci`
- rendered calendar check: July 21 is orange/coral and July 22 is green while the current status remains under review