### PR TITLE
feat(site): Clarify status history semantics

### DIFF
--- a/site/src/app/components/StatusPage.tsx
+++ b/site/src/app/components/StatusPage.tsx
@@ -7,6 +7,7 @@ import {
   HelpCircle,
   History,
   Info,
+  PackageCheck,
 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -493,6 +494,41 @@ function StatusFootnote() {
 }
 
 type HistoryItem = (typeof STATUS_DATA.history)[number];
+type HistoryEventTone = 'operational' | 'update' | 'review' | 'issue';
+
+const HISTORY_EVENT_META: Record<HistoryEventTone, { label: string; description: string }> = {
+  operational: { label: 'All working', description: 'A completed verification found no known issue.' },
+  update: { label: 'Product update', description: 'A version or fix was published.' },
+  review: { label: 'Under review', description: 'Checks or investigation are still in progress.' },
+  issue: { label: 'Known issue', description: 'A user-facing problem was confirmed.' },
+};
+
+const HISTORY_EVENT_TONES = Object.keys(HISTORY_EVENT_META) as HistoryEventTone[];
+
+function getHistoryEventTone(item: HistoryItem): HistoryEventTone {
+  if (isProductUpdate(item)) return 'update';
+  if (item.publicStatus === 'known_issue') return 'issue';
+  if (item.publicStatus === 'maintainer_verified' || item.publicStatus === 'community_verified_reviewed') {
+    return 'operational';
+  }
+  return 'review';
+}
+
+function HistoryEventIcon({ tone, size = 16 }: { tone: HistoryEventTone; size?: number }) {
+  if (tone === 'operational') return <CheckCircle2 size={size} strokeWidth={2} />;
+  if (tone === 'update') return <PackageCheck size={size} strokeWidth={2} />;
+  if (tone === 'issue') return <AlertTriangle size={size} strokeWidth={2} />;
+  return <Clock3 size={size} strokeWidth={2} />;
+}
+
+function HistoryEventPill({ tone }: { tone: HistoryEventTone }) {
+  return (
+    <span className={`status-history-pill is-${tone}`}>
+      <HistoryEventIcon tone={tone} size={13} />
+      {HISTORY_EVENT_META[tone].label}
+    </span>
+  );
+}
 
 function buildVisibleHistory(): HistoryItem[] {
   return [...STATUS_DATA.history];
@@ -533,24 +569,40 @@ function HistoryStatus() {
       <a className="status-home-link" href="/status"><ArrowLeft size={15} /> Current status</a>
       <section className="status-panel" aria-labelledby="history-heading">
         <div className="status-panel-head">
-          <h1 id="history-heading">Verification history</h1>
+          <h1 id="history-heading">Status history</h1>
           <span>Public record</span>
+        </div>
+        <div className="status-history-intro">
+          <p>Every update uses the same meaning and color as the status calendar.</p>
+          <div className="status-history-legend" aria-label="Status history color legend">
+            {HISTORY_EVENT_TONES.map((tone) => (
+              <span className={`is-${tone}`} title={HISTORY_EVENT_META[tone].description} key={tone}>
+                <i aria-hidden="true" />
+                {HISTORY_EVENT_META[tone].label}
+              </span>
+            ))}
+          </div>
         </div>
         <div className="status-history-list">
           {buildHistoryGroups().map((group) => (
             <section className="status-history-group" aria-labelledby={`history-${group.key}`} key={group.key}>
               <h3 id={`history-${group.key}`}>{group.label}</h3>
-              {group.items.map((item) => (
-                <article className="status-history-row" key={`${item.date}-${item.title}`}>
-                  <StatusIcon status={item.publicStatus} size={16} />
-                  <time>{formatStatusDate(item.date)}</time>
-                  <div>
-                    <strong>{item.title}</strong>
-                    <p>{item.summary}</p>
-                  </div>
-                  <StatusPill status={item.publicStatus} />
-                </article>
-              ))}
+              {group.items.map((item) => {
+                const tone = getHistoryEventTone(item);
+                return (
+                  <article className={`status-history-row is-${tone}`} key={`${item.date}-${item.title}`}>
+                    <span className={`status-history-icon is-${tone}`} aria-hidden="true">
+                      <HistoryEventIcon tone={tone} size={15} />
+                    </span>
+                    <time>{formatStatusDate(item.date)}</time>
+                    <div>
+                      <strong>{item.title}</strong>
+                      <p>{item.summary}</p>
+                    </div>
+                    <HistoryEventPill tone={tone} />
+                  </article>
+                );
+              })}
             </section>
           ))}
         </div>

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -3886,7 +3886,77 @@
 }
 
 .site-root.is-status-view .status-page .status-history-list {
-  margin-top: 8px;
+  margin-top: 0;
+}
+
+.site-root.is-status-view .status-page .status-history-intro {
+  padding: 22px 18px 20px;
+  border-bottom: 1px solid rgba(15, 15, 13, 0.14);
+  background: rgba(243, 238, 226, 0.52);
+}
+
+.site-root.is-status-view .status-page .status-history-intro > p {
+  margin: 0;
+  color: rgba(15, 15, 13, 0.62);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.site-root.is-status-view .status-page .status-history-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px 18px;
+  margin-top: 15px;
+}
+
+.site-root.is-status-view .status-page .status-history-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: rgba(15, 15, 13, 0.68);
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.site-root.is-status-view .status-page .status-history-legend i {
+  width: 9px;
+  height: 9px;
+  border-radius: 3px;
+  background: var(--history-accent);
+}
+
+.site-root.is-status-view .status-page .status-history-legend .is-operational,
+.site-root.is-status-view .status-page .status-history-row.is-operational {
+  --history-accent: var(--home-accent);
+  --history-ink: #6e58b9;
+  --history-soft: rgba(136, 115, 207, 0.11);
+  --history-border: rgba(136, 115, 207, 0.3);
+}
+
+.site-root.is-status-view .status-page .status-history-legend .is-update,
+.site-root.is-status-view .status-page .status-history-row.is-update {
+  --history-accent: var(--status-update);
+  --history-ink: #27785f;
+  --history-soft: rgba(39, 142, 114, 0.1);
+  --history-border: rgba(39, 142, 114, 0.28);
+}
+
+.site-root.is-status-view .status-page .status-history-legend .is-review,
+.site-root.is-status-view .status-page .status-history-row.is-review {
+  --history-accent: #b9a8ef;
+  --history-ink: #7058bd;
+  --history-soft: rgba(185, 168, 239, 0.13);
+  --history-border: rgba(112, 88, 189, 0.24);
+}
+
+.site-root.is-status-view .status-page .status-history-legend .is-issue,
+.site-root.is-status-view .status-page .status-history-row.is-issue {
+  --history-accent: #d85d4a;
+  --history-ink: #b74e3e;
+  --history-soft: rgba(216, 93, 74, 0.09);
+  --history-border: rgba(216, 93, 74, 0.28);
 }
 
 .site-root.is-status-view .status-page .status-history-group h3 {
@@ -3907,11 +3977,41 @@
   padding: 26px 18px;
   grid-template-columns: 22px 120px minmax(0, 1fr) auto;
   border-bottom: 1px solid rgba(15, 15, 13, 0.14);
+  box-shadow: inset 3px 0 0 var(--history-accent);
+  background: transparent;
+}
+
+.site-root.is-status-view .status-page .status-history-icon {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 7px;
+  border: 1px solid var(--history-border);
+  color: var(--history-ink);
+  background: var(--home-cream);
 }
 
 .site-root.is-status-view .status-page .status-history-row time,
-.site-root.is-status-view .status-page .status-history-row .status-pill {
+.site-root.is-status-view .status-page .status-history-row .status-history-pill {
   font-family: var(--font-mono);
+}
+
+.site-root.is-status-view .status-page .status-history-pill {
+  min-height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 0 9px;
+  border: 1px solid var(--history-border);
+  border-radius: 999px;
+  color: var(--history-ink);
+  background: var(--home-cream);
+  font-size: 10px;
+  font-weight: 700;
+  white-space: nowrap;
 }
 
 .site-root.is-status-view .status-page .status-history-row p {
@@ -4076,7 +4176,7 @@
 
   .site-root.is-status-view .status-page .status-history-row time,
   .site-root.is-status-view .status-page .status-history-row > div,
-  .site-root.is-status-view .status-page .status-history-row .status-pill {
+  .site-root.is-status-view .status-page .status-history-row .status-history-pill {
     grid-column: 2;
   }
 }
@@ -4345,7 +4445,7 @@
     grid-row: 2;
   }
 
-  .site-root.is-status-view .status-page .status-history-row .status-pill {
+  .site-root.is-status-view .status-page .status-history-row .status-history-pill {
     grid-column: 3;
     grid-row: 1;
     justify-self: end;
@@ -4368,7 +4468,7 @@
   .site-root.is-status-view .status-page .status-history-row {
     grid-template-columns: 20px minmax(0, 1fr);
   }
-  .site-root.is-status-view .status-page .status-history-row .status-pill {
+  .site-root.is-status-view .status-page .status-history-row .status-history-pill {
     grid-column: 2;
     grid-row: 2;
     justify-self: start;
@@ -4398,7 +4498,7 @@
     grid-row: 2;
   }
 
-  .site-root.is-status-view .status-page .status-history-row .status-pill {
+  .site-root.is-status-view .status-page .status-history-row .status-history-pill {
     grid-column: 3;
     grid-row: 1;
     justify-self: end;


### PR DESCRIPTION
## Summary

- align status-history colors with the status calendar
- distinguish product updates from operational verification instead of labeling both as working
- add a concise legend and semantic event labels for all working, product update, under review, and known issue
- use flat Ghostify-branded surfaces, outlined icons, and color rails without decorative gradients
- preserve responsive behavior across desktop and mobile layouts

## Validation

- `npm run build` in `site/`
- `npm audit --audit-level=high` in `site/`
- desktop and 390×844 browser visual checks
- verified no horizontal overflow, no console warnings/errors, and no gradients on history rows