### PR TITLE
feat(ci): Add fast daily verification path

### DIFF
--- a/.github/workflows/daily-verification.yml
+++ b/.github/workflows/daily-verification.yml
@@ -311,6 +311,16 @@ jobs:
 
           Until this PR is merged, the website and popup keep showing the latest previously merged status.
 
+          ### Option 1 — everything passed
+
+          - [ ] I tested Store-installed Ghostify v${TARGET_VERSION} using authorized accounts, and every check in the detailed matrix below passed.
+
+          If this is true, check only this box and merge. You do not need to check the detailed boxes.
+
+          ### Option 2 — something failed or remains unverified
+
+          Do not check the all-passed box. Check each passing item below and leave failed or unverified items unchecked. **Do not merge this green verification PR.** Publish a yellow status update for the affected controls, then close this PR.
+
           - [ ] I tested the extension installed from the Chrome Web Store, not an unpacked development build.
           - [ ] GH-POPUP-001 — the popup opens, reports v${TARGET_VERSION}, and persists toggle changes.
           - [ ] Sender-side and story-owner confirmation used only authorized test accounts.
@@ -329,7 +339,7 @@ jobs:
           - [ ] GH-FB-GROUP-SEND-001 sends a group-chat message normally
           - [ ] GH-FB-MEDIA-001 still plays normally
 
-          Merging is the maintainer attestation that Store build v${TARGET_VERSION} passed this full checklist. Automated checks do not independently prove live Meta behavior, and this workflow never auto-checks or auto-merges.
+          Merging is the maintainer attestation that Store build v${TARGET_VERSION} passed either the all-passed check or every applicable detailed check. Automated checks do not independently prove live Meta behavior, and this workflow never auto-checks or auto-merges.
           EOF
           else
             cat > "$RUNNER_TEMP/pr-body.md" <<EOF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ grouped by version, with the most recent changes first.
 - Changed daily verification into one Store-version-specific, refreshable pull
   request: merging remains an explicit maintainer attestation, while Store
   publication or public-status changes immediately refresh the proposal.
+- Added a one-checkbox path when every live check passes, while retaining the
+  detailed matrix for recording individual failures without publishing a
+  misleading green status.
 - Split daily status validation from proposal publishing so third-party build
   dependencies run with read-only repository access, and bot-created proposals
   explicitly approve required pull-request CI for their exact commit.

--- a/test/daily-verification-git.test.js
+++ b/test/daily-verification-git.test.js
@@ -36,6 +36,13 @@ assert(
     'the maintainer checklist must cover popup identity and high-risk Facebook regressions'
 );
 assert(
+    workflow.includes('### Option 1 — everything passed') &&
+        workflow.includes('check only this box and merge') &&
+        workflow.includes('### Option 2 — something failed or remains unverified') &&
+        workflow.includes('Do not merge this green verification PR'),
+    'daily verification must offer a one-check success path and a non-green diagnostic path'
+);
+assert(
     validateJob.includes('permissions:\n      contents: read') &&
         validateJob.includes('run: npm run ci:verification') &&
         !validateJob.includes('contents: write') &&

--- a/test/prepare-status-update.test.js
+++ b/test/prepare-status-update.test.js
@@ -302,6 +302,8 @@ function testDailyWorkflowIsSingleRefreshableMaintainerApprovalPr() {
     assert(workflow.includes('base_sha'));
     assert(workflow.includes('main changed while this proposal was being validated'));
     assert(workflow.includes('git push --force-with-lease'));
+    assert(workflow.includes('check only this box and merge'));
+    assert(workflow.includes('Do not merge this green verification PR'));
     assert(workflow.includes('Merging is the maintainer attestation'));
     assert(!workflow.includes('gh pr merge'));
     assert(!workflow.includes('enable-auto-merge'));


### PR DESCRIPTION
## Summary

- add a one-checkbox path when every live verification check passes
- retain the full per-feature matrix for diagnosing a failed or unverified control
- make the failure route explicitly block merging the green status proposal

## Validation

- npm run ci
- focused status workflow tests
- actionlint 1.7.12

No extension runtime behavior changes.