### PR TITLE
fix(deps): Patch development tooling advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2204,9 +2204,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -4099,9 +4099,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

- update the transitive development dependency `fast-uri` from 3.1.4 to 3.1.5
- update the transitive development dependency `undici` from 7.28.0 to 7.29.0
- keep the existing dependency graph, package manifest, runtime code, and audit policy unchanged

## Root cause

New security advisories published for the locked versions caused the complete dependency audit on `main` to fail after the August 4 status update. Both patched versions satisfy the existing ranges under `web-ext` and `addons-linter`, so no override or parent upgrade is required.

## Validation

- `npm ci`
- `npm ls fast-uri undici --all`
- `npm run audit:runtime`
- `npm run audit:high`
- `npm audit signatures`
- `npm run ci`

The updated packages are development tooling and are not included in the Chromium or Firefox extension packages.