### PR TITLE
fix(ci): Strengthen dependency audit gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,35 @@ jobs:
       - name: Run actionlint
         run: docker run --rm -v "${{ github.workspace }}:/repo" --workdir /repo rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 -color
 
+  extension-audit:
+    name: Extension dependency audit
+    runs-on: ubuntu-24.04
+    needs: change-scope
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.x
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit extension runtime dependencies
+        if: needs.change-scope.outputs.status-only == 'true'
+        run: npm run audit:runtime
+
+      - name: Audit complete extension dependency graph
+        if: needs.change-scope.outputs.status-only != 'true'
+        run: npm run audit:high
+
   chromium-extension:
     name: Chromium extension checks
     runs-on: ubuntu-24.04
@@ -92,14 +121,6 @@ jobs:
 
       - name: Run Chromium functional and package checks
         run: npm run ci:chromium:checks
-
-      - name: Audit extension runtime dependencies
-        if: needs.change-scope.outputs.status-only == 'true'
-        run: npm run audit:runtime
-
-      - name: Audit complete extension dependency graph
-        if: needs.change-scope.outputs.status-only != 'true'
-        run: npm run audit:high
 
   firefox-extension:
     name: Firefox extension checks
@@ -126,24 +147,34 @@ jobs:
       - name: Run Firefox functional and package checks
         run: npm run ci:firefox:checks
 
-      - name: Audit extension runtime dependencies
-        if: needs.change-scope.outputs.status-only == 'true'
-        run: npm run audit:runtime
-
-      - name: Audit complete extension dependency graph
-        if: needs.change-scope.outputs.status-only != 'true'
-        run: npm run audit:high
-
   extension:
     name: Extension checks
     runs-on: ubuntu-24.04
+    if: always()
     needs:
       - chromium-extension
       - firefox-extension
+      - extension-audit
+      - release-package
+      - firefox-release-package
 
     steps:
-      - name: Confirm browser checks passed
-        run: echo "Chromium and Firefox extension checks passed."
+      - name: Confirm required extension gates passed
+        shell: bash
+        env:
+          CHROMIUM_RESULT: ${{ needs.chromium-extension.result }}
+          FIREFOX_RESULT: ${{ needs.firefox-extension.result }}
+          AUDIT_RESULT: ${{ needs.extension-audit.result }}
+          CHROMIUM_PACKAGE_RESULT: ${{ needs.release-package.result }}
+          FIREFOX_PACKAGE_RESULT: ${{ needs.firefox-release-package.result }}
+        run: |
+          for result in "$CHROMIUM_RESULT" "$FIREFOX_RESULT" "$AUDIT_RESULT" "$CHROMIUM_PACKAGE_RESULT" "$FIREFOX_PACKAGE_RESULT"; do
+            if [[ "$result" != "success" ]]; then
+              echo "A required extension gate did not pass." >&2
+              exit 1
+            fi
+          done
+          echo "Browser checks, dependency audit, and release package dry runs passed."
 
   secret-scan:
     name: Secret scan
@@ -203,6 +234,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - chromium-extension
+      - extension-audit
       - secret-scan
 
     steps:
@@ -244,6 +276,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - firefox-extension
+      - extension-audit
       - secret-scan
 
     steps:

--- a/.github/workflows/daily-verification.yml
+++ b/.github/workflows/daily-verification.yml
@@ -55,6 +55,7 @@ jobs:
       target_version: ${{ steps.proposal.outputs.target_version }}
       verification_version: ${{ steps.proposal.outputs.verification_version }}
       base_status: ${{ steps.proposal.outputs.base_status }}
+      dependency_review_failed: ${{ steps.dependency-review-status.outputs.failed }}
     env:
       MODE: ${{ github.event.inputs.mode || 'verified' }}
       FEATURES: ${{ github.event.inputs.features || '' }}
@@ -183,14 +184,25 @@ jobs:
           fi
           git diff --check
 
-      - name: Record complete dependency review warning
-        if: >-
-          steps.extension-dependency-review.outcome == 'failure' ||
-          steps.site-dependency-review.outcome == 'failure'
+      - name: Record complete dependency review status
+        id: dependency-review-status
+        if: steps.proposal.outputs.ready == 'true'
         shell: bash
+        env:
+          EXTENSION_REVIEW_OUTCOME: ${{ steps.extension-dependency-review.outcome }}
+          SITE_REVIEW_OUTCOME: ${{ steps.site-dependency-review.outcome }}
         run: |
-          echo "::warning::The complete dependency review needs maintainer attention."
-          echo "A complete dependency audit did not pass. The proposal may still be opened. Runtime dependency findings and validation failures block required CI; development-tool findings remain visible for separate maintainer review." >> "$GITHUB_STEP_SUMMARY"
+          failed=false
+          if [[ "$EXTENSION_REVIEW_OUTCOME" == "failure" || "$SITE_REVIEW_OUTCOME" == "failure" ]]; then
+            failed=true
+            echo "::warning::The complete dependency review needs maintainer attention."
+            if [[ "$MODE" == "verified" ]]; then
+              echo "A complete dependency audit did not pass. The green verification proposal will be opened as a draft and must not be merged until the finding is resolved. Runtime dependency findings and validation failures remain blocking." >> "$GITHUB_STEP_SUMMARY"
+            else
+              echo "A complete dependency audit did not pass. The yellow status proposal may still be reviewed and merged so a user-facing issue is not hidden. Runtime dependency findings and validation failures remain blocking." >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+          echo "failed=$failed" >> "$GITHUB_OUTPUT"
 
   publish-proposal:
     name: Publish maintainer approval proposal
@@ -249,6 +261,26 @@ jobs:
           fi
           node scripts/prepare-status-update.js "${args[@]}"
 
+      - name: Protect existing green proposal during dependency review failure
+        if: >-
+          needs.validate-proposal.outputs.ready == 'true' &&
+          env.MODE == 'verified' &&
+          needs.validate-proposal.outputs.dependency_review_failed == 'true'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pr_number="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$DAILY_BRANCH" --json number --jq '.[0].number // empty')"
+          if [[ -n "$pr_number" ]]; then
+            if [[ "$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)" != "true" ]]; then
+              gh pr ready "$pr_number" --repo "$GITHUB_REPOSITORY" --undo
+            fi
+            if [[ "$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)" != "true" ]]; then
+              echo "Refusing to refresh an audit-failing green proposal that could not be protected as a draft." >&2
+              exit 1
+            fi
+          fi
+
       - name: Push or refresh proposal branch
         id: publish-branch
         if: needs.validate-proposal.outputs.ready == 'true'
@@ -294,8 +326,19 @@ jobs:
           TARGET_VERSION: ${{ needs.validate-proposal.outputs.target_version }}
           VERIFICATION_VERSION: ${{ needs.validate-proposal.outputs.verification_version }}
           BASE_STATUS: ${{ needs.validate-proposal.outputs.base_status }}
+          DEPENDENCY_REVIEW_FAILED: ${{ needs.validate-proposal.outputs.dependency_review_failed }}
+          VALIDATION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          dependency_warning=""
+          if [[ "$DEPENDENCY_REVIEW_FAILED" == "true" ]]; then
+            if [[ "$MODE" == "verified" ]]; then
+              dependency_warning="$(printf '> [!WARNING]\n> The complete development dependency audit did not pass. This green verification proposal is a draft and must not be merged until the finding is resolved. Review the [validation workflow](%s).\n' "$VALIDATION_RUN_URL")"
+            else
+              dependency_warning="$(printf '> [!WARNING]\n> The complete development dependency audit did not pass. This yellow status update may still be reviewed and merged so the user-facing issue is not hidden. Review the [validation workflow](%s).\n' "$VALIDATION_RUN_URL")"
+            fi
+          fi
+
           if [[ "$MODE" == "verified" ]]; then
             if [[ "$BASE_STATUS" != "maintainer_verified" || "$VERIFICATION_VERSION" != "$TARGET_VERSION" ]]; then
               recovery_note="The current public status is **${BASE_STATUS}** and its recorded verification build is v${VERIFICATION_VERSION}. Merging this PR declares the current Store build fully verified and resolves any superseded yellow status only after every check below passes."
@@ -306,6 +349,8 @@ jobs:
           ## Daily verification — ${TODAY}
 
           **Target Chrome Web Store build: v${TARGET_VERSION}**
+
+          ${dependency_warning}
 
           ${recovery_note}
 
@@ -345,6 +390,8 @@ jobs:
             cat > "$RUNNER_TEMP/pr-body.md" <<EOF
           ## Public status update — ${TODAY}
 
+          ${dependency_warning}
+
           This PR proposes a yellow **${MODE}** update for: ${FEATURES}.
 
           - [ ] The affected feature ids are correct.
@@ -358,11 +405,18 @@ jobs:
           pr_number="$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$BRANCH" --json number --jq '.[0].number // empty')"
           if [[ -n "$pr_number" ]]; then
             gh pr edit "$pr_number" --repo "$GITHUB_REPOSITORY" --title "$TITLE" --body-file "$RUNNER_TEMP/pr-body.md"
-            if [[ "$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)" == "true" ]]; then
+            is_draft="$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)"
+            if [[ "$MODE" == "verified" && "$DEPENDENCY_REVIEW_FAILED" == "true" && "$is_draft" != "true" ]]; then
+              gh pr ready "$pr_number" --repo "$GITHUB_REPOSITORY" --undo
+            elif [[ "$MODE" != "verified" || "$DEPENDENCY_REVIEW_FAILED" != "true" ]] && [[ "$is_draft" == "true" ]]; then
               gh pr ready "$pr_number" --repo "$GITHUB_REPOSITORY"
             fi
           else
-            gh pr create --repo "$GITHUB_REPOSITORY" --base main --head "$BRANCH" --title "$TITLE" --body-file "$RUNNER_TEMP/pr-body.md"
+            create_args=(--base main --head "$BRANCH" --title "$TITLE" --body-file "$RUNNER_TEMP/pr-body.md")
+            if [[ "$MODE" == "verified" && "$DEPENDENCY_REVIEW_FAILED" == "true" ]]; then
+              create_args+=(--draft)
+            fi
+            gh pr create --repo "$GITHUB_REPOSITORY" "${create_args[@]}"
           fi
 
       - name: Approve required pull-request CI for the proposal commit

--- a/test/daily-verification-git.test.js
+++ b/test/daily-verification-git.test.js
@@ -57,9 +57,10 @@ assert(
     validateJob.includes('id: extension-dependency-review') &&
         validateJob.includes('id: site-dependency-review') &&
         validateJob.includes('continue-on-error: true') &&
-        validateJob.includes('Runtime dependency findings and validation failures block required CI') &&
-        validateJob.includes('development-tool findings remain visible for separate maintainer review'),
-    'complete dependency audit warnings must distinguish blocking runtime findings from development-tool review'
+        validateJob.includes('id: dependency-review-status') &&
+        validateJob.includes('dependency_review_failed: ${{ steps.dependency-review-status.outputs.failed }}') &&
+        validateJob.includes('The green verification proposal will be opened as a draft and must not be merged'),
+    'complete dependency audit findings must be exposed to the publishing job and block a ready proposal'
 );
 assert(
     packageJson.scripts['audit:runtime'].includes('--omit=dev') &&
@@ -90,10 +91,28 @@ assert(
     'required CI must grant the runtime-only audit path solely from an exact PR or merge-group diff'
 );
 assert(
-    ciWorkflow.match(/run: npm run audit:runtime/g)?.length === 3 &&
-        ciWorkflow.match(/run: npm run audit:high/g)?.length === 2 &&
+    ciWorkflow.match(/run: npm run audit:runtime/g)?.length === 2 &&
+        ciWorkflow.match(/run: npm run audit:high/g)?.length === 1 &&
         ciWorkflow.includes('run: npm audit --audit-level=high'),
-    'status-only CI must block on runtime audits while other changes retain complete audits'
+    'status-only CI must run one extension runtime audit while other changes retain one complete extension audit'
+);
+assert(
+    ciWorkflow.includes('name: Extension dependency audit') &&
+        ciWorkflow.includes('if: always()') &&
+        ciWorkflow.includes('- extension-audit') &&
+        ciWorkflow.includes('- release-package') &&
+        ciWorkflow.includes('- firefox-release-package') &&
+        ciWorkflow.includes('A required extension gate did not pass.'),
+    'the required Extension checks context must aggregate browser, audit, and package gates without skip-based bypasses'
+);
+const releasePackageJob = ciWorkflow.slice(
+    ciWorkflow.indexOf('  release-package:'),
+    ciWorkflow.indexOf('  firefox-release-package:')
+);
+const firefoxReleasePackageJob = ciWorkflow.slice(ciWorkflow.indexOf('  firefox-release-package:'));
+assert(
+    releasePackageJob.includes('- extension-audit') && firefoxReleasePackageJob.includes('- extension-audit'),
+    'release-package jobs must not create or upload artifacts before the extension dependency audit passes'
 );
 assert(
     dependencyAuditWorkflow.includes('schedule:') &&
@@ -107,6 +126,22 @@ assert(
         publishJob.includes('pull-requests: write') &&
         !publishJob.includes('run: npm ci'),
     'the write-enabled publishing job must not install package dependencies'
+);
+assert(
+    publishJob.includes('DEPENDENCY_REVIEW_FAILED: ${{ needs.validate-proposal.outputs.dependency_review_failed }}') &&
+        publishJob.includes('The complete development dependency audit did not pass.') &&
+        publishJob.includes('This yellow status update may still be reviewed and merged') &&
+        publishJob.includes('"$MODE" == "verified" && "$DEPENDENCY_REVIEW_FAILED" == "true"') &&
+        publishJob.includes('gh pr ready "$pr_number" --repo "$GITHUB_REPOSITORY" --undo') &&
+        publishJob.includes('create_args+=(--draft)'),
+    'green verification proposals must remain drafts on audit failure without delaying yellow issue disclosure'
+);
+assert(
+    publishJob.indexOf('Protect existing green proposal during dependency review failure') >= 0 &&
+        publishJob.indexOf('Protect existing green proposal during dependency review failure') <
+            publishJob.indexOf('Push or refresh proposal branch') &&
+        publishJob.includes('Refusing to refresh an audit-failing green proposal that could not be protected as a draft.'),
+    'an existing green proposal must become draft before its branch is refreshed with audit-failing status data'
 );
 assert(
     publishJob.includes('echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"') &&


### PR DESCRIPTION
## Summary

- run the extension dependency audit once in a dedicated CI job instead of reporting one finding as separate Chromium and Firefox failures
- make the required `Extension checks` context cover both browser checks, the dependency audit, and both release-package dry runs
- prevent package artifacts from being created when the dependency audit fails
- surface complete-audit failures prominently in daily status proposals
- keep green verification proposals draft until audit findings are resolved while allowing urgent yellow issue updates to remain publishable
- protect an existing green proposal as draft before refreshing its branch

## Why

The August 4 daily workflow detected a development-tool advisory before publishing its proposal, but the warning was easy to miss. The status-only PR appeared green, and the full audit then failed on `main`. The same root finding also appeared as two browser failures because the audit ran inside both browser jobs.

This change preserves the existing security policy: exact status-only changes use the blocking runtime audit, ordinary changes and `main` use the blocking complete audit, and the weekly complete audit remains unchanged.

## Validation

- `npm ci`
- `npm run test:status`
- pinned `actionlint` validation
- `npm run audit:runtime`
- `npm run audit:high`
- `npm run ci`
- independent workflow and security review