### PR TITLE
fix(deps): Patch js-yaml advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2815,9 +2815,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- update the transitive development dependency js-yaml from 4.3.0 to 4.3.1
- resolve GHSA-5p4m-2wfm-xmqj without changing runtime dependencies

## Validation
- npm ci
- npm ls js-yaml --all
- npm run audit:runtime
- npm run audit:high
- npm run ci
- site: npm ci, npm run build, npm run audit:runtime, npm run audit:high