### PR TITLE
fix(facebook): Block mobile story view receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ section, and GitHub Releases should match the facts recorded here.
 The format follows the spirit of Keep a Changelog: human-written entries,
 grouped by version, with the most recent changes first.
 
+## [2.0.7] - Unreleased
+
+### Added
+
+- Added captured WebLite regression coverage for Facebook mobile story views,
+  including explicit fail-open cases for unrelated story traffic.
+
+### Fixed
+
+- Added a narrowly scoped Firefox Android block for the captured Facebook
+  mobile-site WebLite story-view receipt while preserving story navigation,
+  media playback, and visibility telemetry. Story-owner viewer-list proof
+  remains required before Android publication.
+
 ## [2.0.6] - 2026-07-22
 
 ### Added

--- a/dist/config/patterns.json
+++ b/dist/config/patterns.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.6",
+    "version": "2.0.7",
     "killSwitch": [],
     "patterns": {
         "igTyping": [

--- a/dist/js/content.js
+++ b/dist/js/content.js
@@ -64,7 +64,7 @@
 
   // src/content.js
   var FALLBACK_CONFIG = {
-    version: "2.0.6",
+    version: "2.0.7",
     killSwitch: [],
     patterns: {
       igTyping: ["indicate_activity", "typing_indicator", "activity_indicator", "is_typing", "direct_v2/threads/broadcast/typing", "direct_v2/threads/typing", "sendtypingindicator", "send_typing_indicator", "typing_on", "is_composing"],

--- a/dist/js/ghost.js
+++ b/dist/js/ghost.js
@@ -678,6 +678,52 @@
       "mark_story_read"
     ]);
   }
+  function isFacebookMobileStorySeenWebLiteFrame(data, urlString) {
+    if (!isFacebookMobileStoryViewer()) return false;
+    if (!isFacebookWebLiteSocket(urlString)) return false;
+    const bytes = getBinaryFrameBytes(data);
+    if (!bytes || bytes.byteLength !== 54) return false;
+    const declaredLength = bytes[0] << 8 | bytes[1];
+    if (declaredLength !== bytes.byteLength - 2 || bytes[2] !== 83) return false;
+    if (!bytesAreZero(bytes, 23, 31)) return false;
+    if (bytes[31] !== 66) return false;
+    if (!bytesAre(bytes, 36, 40, 255)) return false;
+    return bytes[48] === 12;
+  }
+  function isFacebookMobileStoryViewer() {
+    try {
+      return window.location.hostname.toLowerCase() === "m.facebook.com" && String(window.location.pathname || "").toLowerCase().startsWith("/stories/");
+    } catch (e) {
+      return false;
+    }
+  }
+  function isFacebookWebLiteSocket(urlString) {
+    try {
+      const url = new URL(String(urlString || ""), window.location.href);
+      return url.protocol === "wss:" && url.hostname === "kaios-d.facebook.com" && url.pathname.startsWith("/ws/");
+    } catch (e) {
+      return false;
+    }
+  }
+  function getBinaryFrameBytes(data) {
+    try {
+      if (data instanceof ArrayBuffer) return new Uint8Array(data);
+      if (ArrayBuffer.isView(data)) {
+        return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+      }
+    } catch (e) {
+    }
+    return null;
+  }
+  function bytesAreZero(bytes, start, end) {
+    return bytesAre(bytes, start, end, 0);
+  }
+  function bytesAre(bytes, start, end, expected) {
+    for (let index = start; index < end; index += 1) {
+      if (bytes[index] !== expected) return false;
+    }
+    return true;
+  }
   function isInstagramStoryViewerLookup(str) {
     if (hasExplicitStorySeenSignal(str)) return false;
     return includesAny(str, [
@@ -2201,6 +2247,9 @@
       }
       if (SETTINGS.msgTyping && !isKilled("msgTyping") && isFacebookExplicitMessengerTypingWrite(str, urlString)) {
         return "MSG_TYPING";
+      }
+      if (SETTINGS.msgStory && !isKilled("msgStory") && isFacebookMobileStorySeenWebLiteFrame(data, urlString)) {
+        return "MSG_STORY";
       }
       if (SETTINGS.msgStory && !isKilled("msgStory") && hasExplicitStorySeenSignal(str) && matchesPattern(str, PATTERNS.msgStory)) {
         return "MSG_STORY";

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Ghostify | Hide Seen, Typing & Story Views",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "description": "Control your visibility on Instagram & Facebook/Messenger. Hide typing indicators, read receipts, and story views.",
     "author": "Hendrizzzz",
     "permissions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghostify",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghostify",
-      "version": "2.0.6",
+      "version": "2.0.7",
       "license": "MIT",
       "devDependencies": {
         "esbuild": "^0.28.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghostify",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "private": true,
   "description": "Privacy controls for Instagram, Facebook, and Messenger.",
   "scripts": {

--- a/site/src/app/statusData.json
+++ b/site/src/app/statusData.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "product": "Ghostify",
-  "productVersion": "2.0.6",
+  "productVersion": "2.0.7",
   "generatedAt": "2026-08-10T08:55:21Z",
   "release": {
     "channel": "Chrome Web Store",

--- a/src/content.js
+++ b/src/content.js
@@ -2,7 +2,7 @@ import { GHOSTIFY_SETTINGS_STORAGE_KEY, sanitizePrivacySettingsForPage } from '.
 import { normalizePackagedConfig } from './runtime-config.js';
 
 const FALLBACK_CONFIG = {
-    version: "2.0.6",
+    version: "2.0.7",
     killSwitch: [],
     patterns: {
         igTyping: ['indicate_activity', 'typing_indicator', 'activity_indicator', 'is_typing', 'direct_v2/threads/broadcast/typing', 'direct_v2/threads/typing', 'sendtypingindicator', 'send_typing_indicator', 'typing_on', 'is_composing'],

--- a/src/utils/network.js
+++ b/src/utils/network.js
@@ -283,6 +283,67 @@ function hasExplicitStorySeenSignal(str) {
     ]);
 }
 
+function isFacebookMobileStorySeenWebLiteFrame(data, urlString) {
+    if (!isFacebookMobileStoryViewer()) return false;
+    if (!isFacebookWebLiteSocket(urlString)) return false;
+
+    const bytes = getBinaryFrameBytes(data);
+    if (!bytes || bytes.byteLength !== 54) return false;
+
+    // Firefox Android's m.facebook.com story viewer sends WebLite messages as:
+    // uint16 frame length, varint message code, 12-byte session/message header,
+    // then the action body. The captured seen action is code 83 with the exact
+    // zero-field/flag/QPL shape below. Navigation, visibility, and media frames
+    // use different lengths, codes, or action flags and must stay native.
+    const declaredLength = (bytes[0] << 8) | bytes[1];
+    if (declaredLength !== bytes.byteLength - 2 || bytes[2] !== 83) return false;
+    if (!bytesAreZero(bytes, 23, 31)) return false;
+    if (bytes[31] !== 66) return false;
+    if (!bytesAre(bytes, 36, 40, 0xff)) return false;
+    return bytes[48] === 12;
+}
+
+function isFacebookMobileStoryViewer() {
+    try {
+        return window.location.hostname.toLowerCase() === 'm.facebook.com' &&
+            String(window.location.pathname || '').toLowerCase().startsWith('/stories/');
+    } catch (e) {
+        return false;
+    }
+}
+
+function isFacebookWebLiteSocket(urlString) {
+    try {
+        const url = new URL(String(urlString || ''), window.location.href);
+        return url.protocol === 'wss:' &&
+            url.hostname === 'kaios-d.facebook.com' &&
+            url.pathname.startsWith('/ws/');
+    } catch (e) {
+        return false;
+    }
+}
+
+function getBinaryFrameBytes(data) {
+    try {
+        if (data instanceof ArrayBuffer) return new Uint8Array(data);
+        if (ArrayBuffer.isView(data)) {
+            return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+        }
+    } catch (e) { }
+    return null;
+}
+
+function bytesAreZero(bytes, start, end) {
+    return bytesAre(bytes, start, end, 0);
+}
+
+function bytesAre(bytes, start, end, expected) {
+    for (let index = start; index < end; index += 1) {
+        if (bytes[index] !== expected) return false;
+    }
+    return true;
+}
+
 function isInstagramStoryViewerLookup(str) {
     if (hasExplicitStorySeenSignal(str)) return false;
 
@@ -2123,6 +2184,14 @@ export function shouldBlock(data, url = '', options = {}) {
 
         if (SETTINGS.msgTyping && !isKilled('msgTyping') && isFacebookExplicitMessengerTypingWrite(str, urlString)) {
             return 'MSG_TYPING';
+        }
+
+        if (
+            SETTINGS.msgStory &&
+            !isKilled('msgStory') &&
+            isFacebookMobileStorySeenWebLiteFrame(data, urlString)
+        ) {
+            return 'MSG_STORY';
         }
 
         if (

--- a/test/messenger-send-stability.test.js
+++ b/test/messenger-send-stability.test.js
@@ -779,6 +779,65 @@ const instagramStorySeenMediaGraphQLWithDocId = JSON.stringify({
     }
 });
 
+function makeFacebookWebLiteFrame({ byteLength, opcode, actionFlags = 0 }) {
+    const bytes = new Uint8Array(byteLength);
+    const view = new DataView(bytes.buffer);
+    view.setUint16(0, byteLength - 2);
+    bytes[2] = opcode;
+
+    // Redacted WebLite session/message header captured from Firefox Android.
+    bytes.set([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08], 3);
+    view.setUint32(11, 1);
+
+    if (opcode === 83 && byteLength >= 32) {
+        view.setUint32(15, 66000);
+        view.setUint32(19, 66001);
+        view.setUint32(23, 0);
+        view.setUint16(27, 0);
+        view.setUint16(29, 0);
+
+        let offset = 31;
+        let value = actionFlags;
+        do {
+            let digit = value & 0x7f;
+            value >>>= 7;
+            if (value) digit |= 0x80;
+            bytes[offset++] = digit;
+        } while (value && offset < byteLength);
+
+        if (byteLength === 54 && actionFlags === 66) {
+            bytes.fill(0xff, 36, 40);
+            bytes[48] = 12;
+        }
+    }
+
+    return bytes;
+}
+
+const facebookMobileStorySeenWebLiteFrame = makeFacebookWebLiteFrame({
+    byteLength: 54,
+    opcode: 83,
+    actionFlags: 66
+});
+const facebookMobileStoryNavigationWebLiteFrame = makeFacebookWebLiteFrame({
+    byteLength: 58,
+    opcode: 83,
+    actionFlags: 64
+});
+const facebookMobileStoryNavigationWithPayloadWebLiteFrame = makeFacebookWebLiteFrame({
+    byteLength: 74,
+    opcode: 83,
+    actionFlags: 194
+});
+const facebookMobileStoryMediaTelemetryWebLiteFrame = makeFacebookWebLiteFrame({
+    byteLength: 669,
+    opcode: 4
+});
+const facebookMobileStoryVisibilityWebLiteFrame = makeFacebookWebLiteFrame({
+    byteLength: 36,
+    opcode: 111
+});
+
 function makeGhostPage(page = {}, settings = {}) {
     const fetchCalls = [];
     const beaconCalls = [];
@@ -846,6 +905,7 @@ function makeGhostPage(page = {}, settings = {}) {
         TextDecoder,
         TextEncoder,
         ArrayBuffer,
+        URL,
         URLSearchParams,
         FormData: class { }
     });
@@ -865,6 +925,7 @@ function makeGhostPage(page = {}, settings = {}) {
         TextDecoder,
         TextEncoder,
         ArrayBuffer,
+        URL,
         URLSearchParams,
         FormData: window.FormData,
         localStorage: window.localStorage,
@@ -7195,6 +7256,177 @@ function testMessengerPatchRequestRouteExplicitModulesStayProtected() {
     assert(requestContext.window.__GHOSTIFY_STATUS__?.hooks?.['module_interceptor.hooked']);
 }
 
+async function testFacebookMobileStoryWebLiteSeenFramesAreExactScoped() {
+    const endpoint = 'wss://kaios-d.facebook.com/ws/redacted-channel';
+    const storyPage = {
+        hostname: 'm.facebook.com',
+        pathname: '/stories/redacted-owner/redacted-story/',
+        href: 'https://m.facebook.com/stories/redacted-owner/redacted-story/'
+    };
+    const protectedStoryWindow = makeGhostPage(storyPage);
+    const expectSocketSendCount = (pageWindow, body, url, expected, message) => {
+        const { socket } = websocketSend(pageWindow, body, url);
+        assert.strictEqual(socket.sent.length, expected, message);
+    };
+
+    expectSocketSendCount(
+        protectedStoryWindow,
+        facebookMobileStorySeenWebLiteFrame,
+        endpoint,
+        0,
+        'Firefox Android Facebook story-view receipts must be swallowed on the captured WebLite transport'
+    );
+    expectSocketSendCount(
+        protectedStoryWindow,
+        facebookMobileStorySeenWebLiteFrame.slice().buffer,
+        endpoint,
+        0,
+        'Direct ArrayBuffer story-view receipts must use the same protection'
+    );
+    expectSocketSendCount(
+        protectedStoryWindow,
+        facebookMobileStorySeenWebLiteFrame,
+        'wss://kaios-z.facebook.com/ws/redacted-channel',
+        1,
+        'Unevidenced WebLite endpoints must fail open'
+    );
+    assert.strictEqual(
+        await fetchOutcomeAt(
+            protectedStoryWindow,
+            'https://kaios-d.facebook.com/ws/redacted-channel',
+            facebookMobileStorySeenWebLiteFrame
+        ),
+        'allowed',
+        'The WebLite signature must not block HTTPS requests'
+    );
+    const httpsXhr = xhrSendAt(
+        protectedStoryWindow,
+        'https://kaios-d.facebook.com/ws/redacted-channel',
+        facebookMobileStorySeenWebLiteFrame,
+        'POST'
+    );
+    assert.strictEqual(
+        httpsXhr.xhr.sent,
+        facebookMobileStorySeenWebLiteFrame,
+        'The WebLite signature must stay native on XHR'
+    );
+
+    expectSocketSendCount(
+        protectedStoryWindow,
+        facebookMobileStoryNavigationWebLiteFrame,
+        endpoint,
+        1,
+        'Facebook mobile story navigation frames must stay native'
+    );
+    expectSocketSendCount(
+        protectedStoryWindow,
+        facebookMobileStoryNavigationWithPayloadWebLiteFrame,
+        endpoint,
+        1,
+        'Facebook mobile story navigation frames with an action payload must stay native'
+    );
+    expectSocketSendCount(
+        protectedStoryWindow,
+        facebookMobileStoryMediaTelemetryWebLiteFrame,
+        endpoint,
+        1,
+        'Facebook mobile story media telemetry must not be mistaken for a view receipt'
+    );
+    expectSocketSendCount(
+        protectedStoryWindow,
+        facebookMobileStoryVisibilityWebLiteFrame,
+        endpoint,
+        1,
+        'Facebook mobile story visibility-duration frames must stay native'
+    );
+
+    const offsetBacking = new Uint8Array(facebookMobileStorySeenWebLiteFrame.byteLength + 8);
+    offsetBacking.set(facebookMobileStorySeenWebLiteFrame, 4);
+    expectSocketSendCount(
+        protectedStoryWindow,
+        new Uint8Array(offsetBacking.buffer, 4, facebookMobileStorySeenWebLiteFrame.byteLength),
+        endpoint,
+        0,
+        'Captured story-view matching must honor typed-array byte offsets'
+    );
+
+    const nearMissMutations = [
+        ['declared length', 1, 51],
+        ['message opcode', 2, 82],
+        ['zero action field', 23, 1],
+        ['action flag', 31, 64],
+        ['sentinel', 36, 254],
+        ['QPL flag', 48, 0]
+    ];
+    for (const [label, index, value] of nearMissMutations) {
+        const nearMiss = facebookMobileStorySeenWebLiteFrame.slice();
+        nearMiss[index] = value;
+        expectSocketSendCount(
+            protectedStoryWindow,
+            nearMiss,
+            endpoint,
+            1,
+            `A 54-byte WebLite frame with a different ${label} must fail open`
+        );
+    }
+    expectSocketSendCount(
+        protectedStoryWindow,
+        facebookMobileStorySeenWebLiteFrame,
+        'wss://edge-chat.facebook.com/chat?region=redacted',
+        1,
+        'The mobile story signature must not affect Messenger realtime transports'
+    );
+
+    const feedWindow = makeGhostPage({
+        hostname: 'm.facebook.com',
+        pathname: '/',
+        href: 'https://m.facebook.com/'
+    });
+    expectSocketSendCount(
+        feedWindow,
+        facebookMobileStorySeenWebLiteFrame,
+        endpoint,
+        1,
+        'The captured action signature must remain native outside the Facebook story viewer'
+    );
+
+    const desktopStoryWindow = makeGhostPage({
+        hostname: 'www.facebook.com',
+        pathname: '/stories/redacted-owner/redacted-story/',
+        href: 'https://www.facebook.com/stories/redacted-owner/redacted-story/'
+    });
+    expectSocketSendCount(
+        desktopStoryWindow,
+        facebookMobileStorySeenWebLiteFrame,
+        endpoint,
+        1,
+        'The WebLite signature must not alter Facebook desktop story traffic'
+    );
+
+    const disabledStoryWindow = makeGhostPage(storyPage, { msgStory: false });
+    expectSocketSendCount(
+        disabledStoryWindow,
+        facebookMobileStorySeenWebLiteFrame,
+        endpoint,
+        1,
+        'Turning Facebook Story Hider off must restore the native WebLite view receipt'
+    );
+
+    const killedStoryWindow = makeGhostPage(storyPage);
+    killedStoryWindow.postMessage({
+        type: 'GHOSTIFY_CONFIG_UPDATE',
+        source: 'GHOSTIFY_EXTENSION',
+        config: { killSwitch: ['msgStory'], patterns: {} }
+    });
+    expectSocketSendCount(
+        killedStoryWindow,
+        facebookMobileStorySeenWebLiteFrame,
+        endpoint,
+        1,
+        'The msgStory kill switch must restore the native WebLite view receipt'
+    );
+}
+
 async function testVideoAdAndMediaTrafficIsAllowed() {
     const facebookWatchWindow = makeGhostPage({
         hostname: 'www.facebook.com',
@@ -8843,6 +9075,7 @@ async function testMessageRequestClickGraceKeepsTransportAndBridgeNative() {
     await testNonMawFbsbxPagesAreNotTreatedAsMessenger();
     testManifestInjectsIntoFacebookMawProxyFrames();
     testMessengerPatchRequestRouteExplicitModulesStayProtected();
+    await testFacebookMobileStoryWebLiteSeenFramesAreExactScoped();
     await testVideoAdAndMediaTrafficIsAllowed();
     await testPrivacyWritesStillBlockWithRequestOrMediaContext();
     testFacebookWatchDoesNotSpoofFocus();


### PR DESCRIPTION
## Summary

- block the captured Firefox Android Facebook mobile Story view receipt on the WebLite socket
- keep the matcher restricted to the mobile Story viewer, exact transport, and observed 54-byte frame signature
- add fail-open regression coverage and synchronize generated bundles and version metadata for 2.0.7

## Verification

- `npm run ci`
- Firefox Android 153.0.3 emulator: Facebook Story receipt dropped while media/navigation remained usable
- Instagram Story returned to unseen after refresh; Instagram and Messenger unread state remained preserved

## Manual-pending evidence

- story-owner and sender-side confirmation still require a second-account check
- Messenger encrypted-history PIN prevented message-request hydration and authorized-send smoke tests
- typing smoke tests were intentionally skipped