### PR TITLE
fix(facebook): Preserve queue-routed group sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ grouped by version, with the most recent changes first.
 
 ### Fixed
 
+- Fixed Facebook group messages that could remain stuck in Sending when Meta
+  bundled queue-routed sends with typing or Seen metadata. Ghostify now
+  preserves the message and exact routing identifiers while removing only the
+  blocked privacy metadata.
 - Added a narrowly scoped Firefox Android block for the captured Facebook
   mobile-site WebLite story-view receipt while preserving story navigation,
   media playback, and visibility telemetry. Story-owner viewer-list proof

--- a/dist/js/ghost.js
+++ b/dist/js/ghost.js
@@ -232,10 +232,24 @@
           retainedTasks.push(rawTask);
           continue;
         }
-        if (!sanitized.blockedAll || !Array.isArray(sanitized.value) || sanitized.value.length !== 0) {
+        changed = true;
+        if (sanitized.blockedAll) {
+          if (!Array.isArray(sanitized.value) || sanitized.value.length !== 0) {
+            return unchanged(value);
+          }
+          continue;
+        }
+        if (!Array.isArray(sanitized.value) || sanitized.value.length !== 1) {
           return unchanged(value);
         }
-        changed = true;
+        const rewrittenTask = rewriteJsonValueSource(
+          rawTask,
+          task,
+          sanitized.value[0],
+          0
+        );
+        if (typeof rewrittenTask !== "string") return unchanged(value);
+        retainedTasks.push(rewrittenTask);
       }
       if (!changed || retainedTasks.length === 0) return unchanged(value, changed);
       const nextTasksSource = `[${retainedTasks.join(",")}]`;
@@ -268,7 +282,7 @@
       const tasksSpan = findTopLevelPropertyValueSpan(innerSource, "tasks");
       if (!tasksSpan || innerSource[tasksSpan.start] !== "[") continue;
       const rawTasks = splitJsonArrayElements(innerSource.slice(tasksSpan.start, tasksSpan.end));
-      if (!rawTasks || rawTasks.length < 2) continue;
+      if (!rawTasks || rawTasks.length === 0) continue;
       return {
         prefix,
         outerSource,
@@ -1159,6 +1173,315 @@
       `"${field}": "${value}"`
     ]);
   }
+  function normalizeMessengerPayloadKey(key) {
+    return String(key || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+  }
+  function normalizedMessengerPayloadFields(value) {
+    const fields = {};
+    try {
+      for (const key of Object.keys(value || {})) {
+        fields[normalizeMessengerPayloadKey(key)] = value[key];
+      }
+    } catch (e) {
+    }
+    return fields;
+  }
+  function parseMessengerPayloadObject(value) {
+    if (value && typeof value === "object" && !Array.isArray(value)) return value;
+    if (typeof value !== "string") return null;
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : null;
+    } catch (e) {
+      return null;
+    }
+  }
+  function isPositiveMessengerSendType(value) {
+    if (typeof value === "number") return Number.isFinite(value) && value > 0;
+    if (typeof value !== "string") return false;
+    const normalized = value.trim();
+    return /^\d+$/.test(normalized) && Number(normalized) > 0;
+  }
+  function getQueueRoutedMessengerSendTask(value) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+    const fields = normalizedMessengerPayloadFields(value);
+    if (String(fields.label || "") !== "46") return null;
+    if (typeof fields.queuename !== "string" || !fields.queuename.trim()) return null;
+    const payloadKey = Object.keys(value).find((key) => normalizeMessengerPayloadKey(key) === "payload");
+    if (!payloadKey) return null;
+    const rawPayload = value[payloadKey];
+    const payload = parseMessengerPayloadObject(rawPayload);
+    if (!payload) return null;
+    const payloadFields = normalizedMessengerPayloadFields(payload);
+    const sendType = payloadFields.sendtype;
+    if (!isPositiveMessengerSendType(sendType)) return null;
+    const hasClientMessageId = [
+      "offlinethreadingid",
+      "clientmessageid",
+      "clientmutationid",
+      "otid"
+    ].some((key) => payloadFields[key] != null && String(payloadFields[key]).length > 0);
+    const hasMessagePayload = [
+      "message",
+      "text",
+      "body",
+      "attachment",
+      "sticker",
+      "media",
+      "encryptedmessage",
+      "encryptedpayload",
+      "encryptedblob",
+      "encryptedcontent",
+      "ciphertext",
+      "reaction",
+      "messagereaction",
+      "emoji",
+      "quicklike"
+    ].some((key) => payloadFields[key] != null);
+    return hasClientMessageId && hasMessagePayload ? { payloadKey, rawPayload, payload } : null;
+  }
+  function isNetworkReadReceiptSendFlagKey(key) {
+    return key === "shouldsendreadreceipt" || key === "sendreadreceipt" || key === "sendreadreceipts" || key === "sendreadreceiptflag" || key === "readreceiptenabled";
+  }
+  function isNetworkReadReceiptMutationKey(key) {
+    return key === "lssendreadreceipt" || key === "readreceiptmutation" || key === "sendreadreceiptmutation";
+  }
+  function isNetworkReadWatermarkKey(key) {
+    return key === "lastreadwatermark" || key === "lastreadwatermarkts" || key === "lastseentimems" || key === "readwatermark" || key === "watermarktimestamp";
+  }
+  var NETWORK_MESSAGE_CONTENT_KEYS = /* @__PURE__ */ new Set([
+    "text",
+    "body",
+    "attachment",
+    "sticker",
+    "media",
+    "encryptedmessage",
+    "encryptedpayload",
+    "encryptedblob",
+    "encryptedcontent",
+    "ciphertext",
+    "reaction",
+    "messagereaction",
+    "emoji",
+    "quicklike"
+  ]);
+  function isNetworkMessageContentKey(key) {
+    return NETWORK_MESSAGE_CONTENT_KEYS.has(key);
+  }
+  function isLikelyNetworkReadWatermarkValue(value) {
+    if (typeof value === "number") return Number.isFinite(value) && value >= 1e9;
+    if (typeof value === "string") return /^\d{10,}$/.test(value.trim());
+    return false;
+  }
+  function safeNetworkReadWatermarkValue(value) {
+    const text = String(value).trim();
+    const safe = `1${"0".repeat(Math.max(0, text.length - 1))}`;
+    return typeof value === "number" ? Number(safe) : safe;
+  }
+  function isTruthyNetworkPrivacyValue(value) {
+    if (value === true || value === 1) return true;
+    if (typeof value === "string") {
+      const normalized = value.trim().toLowerCase();
+      return normalized === "true" || normalized === "1";
+    }
+    return !!(value && typeof value === "object");
+  }
+  function sanitizeQueueSendPayloadReadMetadata(value, depth = 0) {
+    if (!value || depth > 6 || typeof value !== "object") {
+      return { value, changed: false };
+    }
+    if (Array.isArray(value)) {
+      let changed2 = false;
+      const next = value.map((item) => {
+        const sanitized = sanitizeQueueSendPayloadReadMetadata(item, depth + 1);
+        changed2 = changed2 || sanitized.changed;
+        return sanitized.value;
+      });
+      return { value: changed2 ? next : value, changed: changed2 };
+    }
+    let changed = false;
+    const clone = {};
+    for (const key of Object.keys(value)) {
+      const child = value[key];
+      const normalizedKey = normalizeMessengerPayloadKey(key);
+      if (isNetworkMessageContentKey(normalizedKey)) {
+        clone[key] = child;
+        continue;
+      }
+      if (isNetworkReadReceiptSendFlagKey(normalizedKey)) {
+        const truthy = isTruthyNetworkPrivacyValue(child);
+        clone[key] = truthy ? false : child;
+        changed = changed || truthy;
+        continue;
+      }
+      if (isNetworkReadReceiptMutationKey(normalizedKey)) {
+        const truthy = isTruthyNetworkPrivacyValue(child);
+        clone[key] = truthy ? null : child;
+        changed = changed || truthy;
+        continue;
+      }
+      if (isNetworkReadWatermarkKey(normalizedKey) && isLikelyNetworkReadWatermarkValue(child)) {
+        clone[key] = safeNetworkReadWatermarkValue(child);
+        changed = changed || clone[key] !== child;
+        continue;
+      }
+      const sanitized = sanitizeQueueSendPayloadReadMetadata(child, depth + 1);
+      clone[key] = sanitized.value;
+      changed = changed || sanitized.changed;
+    }
+    return { value: changed ? clone : value, changed };
+  }
+  function sanitizeQueueRoutedMessengerSendTask(value) {
+    const task = getQueueRoutedMessengerSendTask(value);
+    if (!task || !SETTINGS.msgSeen || isKilled("msgSeen")) {
+      return { value, changed: false, blockedAll: false };
+    }
+    let clone = Object.assign({}, value);
+    let changed = false;
+    if (typeof task.rawPayload === "string") {
+      const sanitizedSource = sanitizeJsonTaskBatchStringSource(
+        task.rawPayload,
+        (candidate) => {
+          const sanitized = sanitizeQueueSendPayloadReadMetadata(candidate);
+          return {
+            value: sanitized.value,
+            changed: sanitized.changed,
+            blockedAll: false
+          };
+        }
+      );
+      if (sanitizedSource.changed && !sanitizedSource.blockedAll && typeof sanitizedSource.value === "string") {
+        clone[task.payloadKey] = sanitizedSource.value;
+        changed = true;
+      }
+    } else {
+      const sanitized = sanitizeQueueSendPayloadReadMetadata(task.payload);
+      if (sanitized.changed) {
+        clone[task.payloadKey] = sanitized.value;
+        changed = true;
+      }
+    }
+    const envelope = {};
+    for (const key of Object.keys(clone)) {
+      if (key !== task.payloadKey) envelope[key] = clone[key];
+    }
+    const sanitizedEnvelope = sanitizeQueueSendPayloadReadMetadata(envelope);
+    if (sanitizedEnvelope.changed) {
+      clone = Object.assign({}, sanitizedEnvelope.value, {
+        [task.payloadKey]: clone[task.payloadKey]
+      });
+      changed = true;
+    }
+    return { value: changed ? clone : value, changed, blockedAll: false };
+  }
+  function parseMessengerStructuredText(value) {
+    const source = String(value || "").trim();
+    if (!source) return null;
+    const candidates = [source];
+    const nullIndex = source.lastIndexOf("\0");
+    if (nullIndex >= 0) candidates.unshift(source.slice(nullIndex + 1).trim());
+    for (const candidate of candidates) {
+      if (!candidate || candidate[0] !== "{" && candidate[0] !== "[") continue;
+      try {
+        return JSON.parse(candidate);
+      } catch (e) {
+        const isolated = isolateFirstMessengerJsonValue(candidate);
+        if (!isolated) continue;
+        try {
+          return JSON.parse(isolated);
+        } catch (parseError) {
+        }
+      }
+    }
+    return null;
+  }
+  function isolateFirstMessengerJsonValue(source) {
+    const first = source[0];
+    if (first !== "{" && first !== "[") return null;
+    const stack = [first];
+    let inString = false;
+    let escaped = false;
+    for (let index = 1; index < source.length; index += 1) {
+      const char = source[index];
+      if (inString) {
+        if (escaped) escaped = false;
+        else if (char === "\\") escaped = true;
+        else if (char === '"') inString = false;
+        continue;
+      }
+      if (char === '"') {
+        inString = true;
+        continue;
+      }
+      if (char === "{" || char === "[") stack.push(char);
+      else if (char === "}" || char === "]") {
+        const open = stack.pop();
+        if (open === "{" && char !== "}" || open === "[" && char !== "]") return null;
+        if (stack.length === 0) return source.slice(0, index + 1);
+      }
+    }
+    return null;
+  }
+  function hasUnsafeNetworkPrivacyMetadata(value, depth = 0) {
+    if (!value || depth > 8) return false;
+    if (typeof value === "string") {
+      const parsed = parseMessengerStructuredText(value);
+      return parsed ? hasUnsafeNetworkPrivacyMetadata(parsed, depth + 1) : false;
+    }
+    if (Array.isArray(value)) {
+      return value.some((item) => hasUnsafeNetworkPrivacyMetadata(item, depth + 1));
+    }
+    if (typeof value !== "object") return false;
+    const fields = normalizedMessengerPayloadFields(value);
+    const label = normalizeMessengerPayloadKey(fields.label);
+    if (label === "6" || label === "21") return true;
+    for (const key of Object.keys(value)) {
+      const child = value[key];
+      const normalizedKey = normalizeMessengerPayloadKey(key);
+      if (isNetworkMessageContentKey(normalizedKey)) continue;
+      if ((isNetworkReadReceiptSendFlagKey(normalizedKey) || isNetworkReadReceiptMutationKey(normalizedKey)) && isTruthyNetworkPrivacyValue(child)) {
+        return true;
+      }
+      if (isNetworkReadWatermarkKey(normalizedKey) && isLikelyNetworkReadWatermarkValue(child) && safeNetworkReadWatermarkValue(child) !== child) {
+        return true;
+      }
+      if (hasUnsafeNetworkPrivacyMetadata(child, depth + 1)) return true;
+    }
+    return false;
+  }
+  function inspectQueueRoutedMessengerEnvelope(value, depth = 0, state = { send: false, unsafe: false }) {
+    if (!value || depth > 8 || state.unsafe) return state;
+    if (typeof value === "string") {
+      const parsed = parseMessengerStructuredText(value);
+      if (parsed) inspectQueueRoutedMessengerEnvelope(parsed, depth + 1, state);
+      return state;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) inspectQueueRoutedMessengerEnvelope(item, depth + 1, state);
+      return state;
+    }
+    if (typeof value !== "object") return state;
+    const task = getQueueRoutedMessengerSendTask(value);
+    if (task) {
+      state.send = true;
+      state.unsafe = hasUnsafeNetworkPrivacyMetadata(value, depth + 1);
+      return state;
+    }
+    if (hasUnsafeNetworkPrivacyMetadata(value, depth)) {
+      state.unsafe = true;
+      return state;
+    }
+    for (const child of Object.values(value)) {
+      inspectQueueRoutedMessengerEnvelope(child, depth + 1, state);
+    }
+    return state;
+  }
+  function hasSafeQueueRoutedMessengerSendIntent(str) {
+    const parsed = parseMessengerStructuredText(str);
+    if (!parsed) return false;
+    const state = inspectQueueRoutedMessengerEnvelope(parsed);
+    return state.send && !state.unsafe;
+  }
   function isMessengerSendWithBundledReadWatermark(str) {
     if (!str.includes("send_type")) return false;
     if (!hasReadReceiptWatermarkContext(str)) return false;
@@ -1168,7 +1491,9 @@
   function hasMessengerMessageSendIntent(str) {
     const text = String(str || "");
     const matchText = text.includes("\\") ? `${text} ${text.replace(/\\/g, "")}` : text;
-    if (!hasMessengerThreadContext(matchText)) return false;
+    const hasQueueRoutedSend = hasSafeQueueRoutedMessengerSendIntent(text);
+    if (!hasMessengerThreadContext(matchText) && !hasQueueRoutedSend) return false;
+    if (hasQueueRoutedSend) return true;
     const hasSendOperationName = includesAny(matchText, [
       "send_message",
       "sendmessage",
@@ -1434,11 +1759,6 @@
       let changed = false;
       const next = [];
       for (const item of value) {
-        const itemText = decode(item).toLowerCase();
-        if (privacyOnlyPredicate(itemText, urlString, options)) {
-          changed = true;
-          continue;
-        }
         const sanitizedItem = sanitizeMessengerNetworkValue(
           item,
           urlString,
@@ -1447,6 +1767,11 @@
           privacyOnlyPredicate
         );
         if (sanitizedItem.blockedAll) {
+          changed = true;
+          continue;
+        }
+        const itemText = decode(sanitizedItem.value).toLowerCase();
+        if (privacyOnlyPredicate(itemText, urlString, options)) {
           changed = true;
           continue;
         }
@@ -1460,6 +1785,8 @@
       };
     }
     if (typeof value === "object") {
+      const queueRoutedSend = sanitizeQueueRoutedMessengerSendTask(value);
+      if (queueRoutedSend.changed) return queueRoutedSend;
       const ownText = decode(value).toLowerCase();
       if (isMessengerNormalThreadListPaginationTask(ownText)) {
         return { value, changed: false, blockedAll: false };

--- a/dist/js/messenger_patch.js
+++ b/dist/js/messenger_patch.js
@@ -225,10 +225,24 @@
           retainedTasks.push(rawTask);
           continue;
         }
-        if (!sanitized.blockedAll || !Array.isArray(sanitized.value) || sanitized.value.length !== 0) {
+        changed = true;
+        if (sanitized.blockedAll) {
+          if (!Array.isArray(sanitized.value) || sanitized.value.length !== 0) {
+            return unchanged(value);
+          }
+          continue;
+        }
+        if (!Array.isArray(sanitized.value) || sanitized.value.length !== 1) {
           return unchanged(value);
         }
-        changed = true;
+        const rewrittenTask = rewriteJsonValueSource(
+          rawTask,
+          task,
+          sanitized.value[0],
+          0
+        );
+        if (typeof rewrittenTask !== "string") return unchanged(value);
+        retainedTasks.push(rewrittenTask);
       }
       if (!changed || retainedTasks.length === 0) return unchanged(value, changed);
       const nextTasksSource = `[${retainedTasks.join(",")}]`;
@@ -261,7 +275,7 @@
       const tasksSpan = findTopLevelPropertyValueSpan(innerSource, "tasks");
       if (!tasksSpan || innerSource[tasksSpan.start] !== "[") continue;
       const rawTasks = splitJsonArrayElements(innerSource.slice(tasksSpan.start, tasksSpan.end));
-      if (!rawTasks || rawTasks.length < 2) continue;
+      if (!rawTasks || rawTasks.length === 0) continue;
       return {
         prefix,
         outerSource,
@@ -1343,11 +1357,33 @@
         const needsInspection = isPostMessageObservationEnabled() || window.__ghostify_shouldBlockTyping() || window.__ghostify_shouldBlockMessengerSeen();
         const text = needsInspection ? stringifyForMatch(message).toLowerCase() : "";
         const hasQueueRoutedSendTask = needsInspection && containsQueueRoutedMessengerSendTask(message);
+        const hasQueueRoutedGroupSendTask = needsInspection && containsQueueRoutedMessengerGroupSendTask(message);
         if (hasNativeMessageRequestBypass() && isMessageRequestHydrationText(text)) {
           return originalPostMessage.apply(this, arguments);
         }
         const blockType = shouldBlockTypingText(text) ? "MSG_TYPING" : shouldBlockSeenText(text) ? "MSG_SEEN" : null;
         tracePostMessageObservation(kind, message, blockType, text);
+        if (hasQueueRoutedSendTask) {
+          const sanitizedQueueSend = sanitizeBridgeMessage(message);
+          if (sanitizedQueueSend.changed && !sanitizedQueueSend.blockedAll) {
+            const transferSafe = filterPostMessageTransfer(transfer, sanitizedQueueSend.value);
+            const hasSeenMetadata = window.__ghostify_shouldBlockMessengerSeen() && includesAnyText(text, [
+              "should_send_read_receipt",
+              "shouldsendreadreceipt",
+              "last_read_watermark",
+              "lastreadwatermark",
+              "readreceiptmutation",
+              "read_receipt_mutation"
+            ]);
+            if (hasSeenMetadata) {
+              window.__GHOSTIFY_SANITIZED_SEEN_BRIDGE_MESSAGES__ = (window.__GHOSTIFY_SANITIZED_SEEN_BRIDGE_MESSAGES__ || 0) + 1;
+            } else {
+              window.__GHOSTIFY_SANITIZED_WORKER_MESSAGES__ = (window.__GHOSTIFY_SANITIZED_WORKER_MESSAGES__ || 0) + 1;
+            }
+            tracePostMessageOutcome(kind, blockType, "sanitize_queue_send", message, text);
+            return forwardSanitizedPostMessage(originalPostMessage, this, sanitizedQueueSend.value, transferSafe);
+          }
+        }
         if (blockType) {
           if (blockType === "MSG_SEEN" && (isMessengerDotCom || isFacebookDotCom || isFacebookMessengerProxy)) {
             const sanitizedRealtimeSeen = sanitizeFacebookRealtimeReadReceiptBridgeMessage(message, text);
@@ -1391,6 +1427,16 @@
               }
             }
             if (hasQueueRoutedSendTask) {
+              if (hasQueueRoutedGroupSendTask) {
+                if (isQueueSendPrivacyBlockCausedOnlyByMessageContent(message, blockType)) {
+                  window.__GHOSTIFY_FACEBOOK_UNSAFE_BLOCKS_SKIPPED__ = (window.__GHOSTIFY_FACEBOOK_UNSAFE_BLOCKS_SKIPPED__ || 0) + 1;
+                  tracePostMessageOutcome(kind, blockType, "queue_send_content_forward", message, text);
+                  return originalPostMessage.apply(this, arguments);
+                }
+                window.__GHOSTIFY_BLOCKED_WORKER_MESSAGES__ = (window.__GHOSTIFY_BLOCKED_WORKER_MESSAGES__ || 0) + 1;
+                tracePostMessageOutcome(kind, blockType, "drop_unsanitized_queue_group_send", message, text);
+                return void 0;
+              }
               window.__GHOSTIFY_FACEBOOK_UNSAFE_BLOCKS_SKIPPED__ = (window.__GHOSTIFY_FACEBOOK_UNSAFE_BLOCKS_SKIPPED__ || 0) + 1;
               tracePostMessageOutcome(kind, blockType, "queue_send_forward", message, text);
               return originalPostMessage.apply(this, arguments);
@@ -1742,6 +1788,30 @@
         return false;
       }
     }
+    function containsQueueRoutedMessengerGroupSendTask(value, depth = 0) {
+      if (!value || depth > 6 || isBinaryPayload(value)) return false;
+      if (Array.isArray(value)) {
+        return value.some((item) => containsQueueRoutedMessengerGroupSendTask(item, depth + 1));
+      }
+      if (typeof value === "string") {
+        const trimmed = value.trim();
+        if (!trimmed || trimmed[0] !== "{" && trimmed[0] !== "[") return false;
+        try {
+          return containsQueueRoutedMessengerGroupSendTask(JSON.parse(trimmed), depth + 1);
+        } catch (e) {
+          return false;
+        }
+      }
+      if (typeof value !== "object") return false;
+      if (isQueueRoutedMessengerGroupSendTask(value)) return true;
+      try {
+        return Object.keys(value).some(
+          (key) => containsQueueRoutedMessengerGroupSendTask(value[key], depth + 1)
+        );
+      } catch (e) {
+        return false;
+      }
+    }
     function isQueueRoutedMessengerSendTask(value) {
       if (!value || typeof value !== "object" || Array.isArray(value)) return false;
       const fields = normalizedBridgeFields(value);
@@ -1751,7 +1821,7 @@
       if (!payload) return false;
       const payloadFields = normalizedBridgeFields(payload);
       const sendType = payloadFields.sendtype;
-      if (!(typeof sendType === "number" && Number.isFinite(sendType) && sendType > 0)) return false;
+      if (!isPositiveMessengerSendType(sendType)) return false;
       const hasClientMessageId = [
         "offlinethreadingid",
         "clientmessageid",
@@ -1777,6 +1847,27 @@
       ].some((key) => payloadFields[key] != null);
       return hasClientMessageId && hasMessagePayload;
     }
+    function isQueueRoutedMessengerGroupSendTask(value) {
+      if (!isQueueRoutedMessengerSendTask(value)) return false;
+      const fields = normalizedBridgeFields(value);
+      const payload = parseBridgeObject(fields.payload);
+      if (!payload) return false;
+      const payloadFields = normalizedBridgeFields(payload);
+      const syncGroup = payloadFields.syncgroup;
+      const hasDirectRecipient = [
+        "otheruserid",
+        "otheruserfbid",
+        "recipientid",
+        "targetid"
+      ].some((key) => payloadFields[key] != null && String(payloadFields[key]).length > 0);
+      return isPositiveMessengerSendType(syncGroup) && !hasDirectRecipient;
+    }
+    function isPositiveMessengerSendType(value) {
+      if (typeof value === "number") return Number.isFinite(value) && value > 0;
+      if (typeof value !== "string") return false;
+      const normalized = value.trim();
+      return /^\d+$/.test(normalized) && Number(normalized) > 0;
+    }
     function normalizedBridgeFields(value) {
       const fields = {};
       try {
@@ -1798,6 +1889,9 @@
       }
     }
     function sanitizeQueueRoutedSendReadMetadata(task) {
+      if (!window.__ghostify_shouldBlockMessengerSeen()) {
+        return { value: task, changed: false, blockedAll: false };
+      }
       let payloadKey;
       try {
         payloadKey = Object.keys(task).find((key) => normalizeBridgeKey(key) === "payload");
@@ -1808,11 +1902,43 @@
       const rawPayload = task[payloadKey];
       const payload = parseBridgeObject(rawPayload);
       if (!payload) return { value: task, changed: false, blockedAll: false };
-      const sanitized = sanitizeQueueSendPayloadReadMetadata(payload);
-      if (!sanitized.changed) return { value: task, changed: false, blockedAll: false };
-      const clone = Object.assign({}, task);
-      clone[payloadKey] = typeof rawPayload === "string" ? JSON.stringify(sanitized.value) : sanitized.value;
-      return { value: clone, changed: true, blockedAll: false };
+      let clone = Object.assign({}, task);
+      let changed = false;
+      if (typeof rawPayload === "string") {
+        const sanitizedSource = sanitizeJsonTaskBatchStringSource(
+          rawPayload,
+          (candidate) => {
+            const sanitized = sanitizeQueueSendPayloadReadMetadata(candidate);
+            return {
+              value: sanitized.value,
+              changed: sanitized.changed,
+              blockedAll: false
+            };
+          }
+        );
+        if (sanitizedSource.changed && !sanitizedSource.blockedAll && typeof sanitizedSource.value === "string") {
+          clone[payloadKey] = sanitizedSource.value;
+          changed = true;
+        }
+      } else {
+        const sanitized = sanitizeQueueSendPayloadReadMetadata(payload);
+        if (sanitized.changed) {
+          clone[payloadKey] = sanitized.value;
+          changed = true;
+        }
+      }
+      const envelope = {};
+      for (const key of Object.keys(clone)) {
+        if (key !== payloadKey) envelope[key] = clone[key];
+      }
+      const sanitizedEnvelope = sanitizeQueueSendPayloadReadMetadata(envelope);
+      if (sanitizedEnvelope.changed) {
+        clone = Object.assign({}, sanitizedEnvelope.value, {
+          [payloadKey]: clone[payloadKey]
+        });
+        changed = true;
+      }
+      return { value: changed ? clone : task, changed, blockedAll: false };
     }
     function sanitizeQueueSendPayloadReadMetadata(value, depth = 0) {
       if (!value || depth > 6 || typeof value !== "object" || isBinaryPayload(value)) {
@@ -1832,6 +1958,10 @@
       for (const key of Object.keys(value)) {
         const child = value[key];
         const normalizedKey = normalizeBridgeKey(key);
+        if (isQueueSendMessageContentKey(normalizedKey)) {
+          clone[key] = child;
+          continue;
+        }
         if (isReadReceiptSendFlagKey(normalizedKey)) {
           const truthy = isTruthyPrivacyValue(child);
           clone[key] = truthy ? false : child;
@@ -1854,6 +1984,53 @@
         changed = changed || sanitized.changed;
       }
       return { value: changed ? clone : value, changed };
+    }
+    function isQueueSendMessageContentKey(key) {
+      return [
+        "text",
+        "body",
+        "attachment",
+        "sticker",
+        "media",
+        "encryptedmessage",
+        "encryptedpayload",
+        "encryptedblob",
+        "encryptedcontent",
+        "ciphertext",
+        "reaction",
+        "messagereaction",
+        "emoji",
+        "quicklike"
+      ].includes(key);
+    }
+    function isQueueSendPrivacyBlockCausedOnlyByMessageContent(value, blockType) {
+      const redacted = redactQueueSendMessageContentForMatch(value);
+      const text = stringifyForMatch(redacted).toLowerCase();
+      if (blockType === "MSG_TYPING") return !shouldBlockTypingText(text);
+      if (blockType === "MSG_SEEN") return !shouldBlockSeenText(text);
+      return false;
+    }
+    function redactQueueSendMessageContentForMatch(value, depth = 0) {
+      if (!value || depth > 8 || isBinaryPayload(value)) return value;
+      if (Array.isArray(value)) {
+        return value.map((item) => redactQueueSendMessageContentForMatch(item, depth + 1));
+      }
+      if (typeof value === "string") {
+        const trimmed = value.trim();
+        if (!trimmed || trimmed[0] !== "{" && trimmed[0] !== "[") return value;
+        try {
+          return redactQueueSendMessageContentForMatch(JSON.parse(trimmed), depth + 1);
+        } catch (e) {
+          return value;
+        }
+      }
+      if (typeof value !== "object") return value;
+      const clone = {};
+      for (const key of Object.keys(value)) {
+        const normalizedKey = normalizeBridgeKey(key);
+        clone[key] = normalizedKey === "message" || isQueueSendMessageContentKey(normalizedKey) ? "[message-content]" : redactQueueSendMessageContentForMatch(value[key], depth + 1);
+      }
+      return clone;
     }
     function tracePostMessageOutcome(kind, blockType, outcome, message, text) {
       if (!isPostMessageObservationEnabled() && !String(outcome || "").startsWith("drop")) return;

--- a/src/messenger_patch.js
+++ b/src/messenger_patch.js
@@ -1307,6 +1307,7 @@ import {
                 window.__ghostify_shouldBlockMessengerSeen();
             const text = needsInspection ? stringifyForMatch(message).toLowerCase() : '';
             const hasQueueRoutedSendTask = needsInspection && containsQueueRoutedMessengerSendTask(message);
+            const hasQueueRoutedGroupSendTask = needsInspection && containsQueueRoutedMessengerGroupSendTask(message);
             if (hasNativeMessageRequestBypass() && isMessageRequestHydrationText(text)) {
                 return originalPostMessage.apply(this, arguments);
             }
@@ -1315,6 +1316,28 @@ import {
                 (shouldBlockSeenText(text) ? 'MSG_SEEN' : null);
 
             tracePostMessageObservation(kind, message, blockType, text);
+
+            if (hasQueueRoutedSendTask) {
+                const sanitizedQueueSend = sanitizeBridgeMessage(message);
+                if (sanitizedQueueSend.changed && !sanitizedQueueSend.blockedAll) {
+                    const transferSafe = filterPostMessageTransfer(transfer, sanitizedQueueSend.value);
+                    const hasSeenMetadata = window.__ghostify_shouldBlockMessengerSeen() && includesAnyText(text, [
+                        'should_send_read_receipt',
+                        'shouldsendreadreceipt',
+                        'last_read_watermark',
+                        'lastreadwatermark',
+                        'readreceiptmutation',
+                        'read_receipt_mutation'
+                    ]);
+                    if (hasSeenMetadata) {
+                        window.__GHOSTIFY_SANITIZED_SEEN_BRIDGE_MESSAGES__ = (window.__GHOSTIFY_SANITIZED_SEEN_BRIDGE_MESSAGES__ || 0) + 1;
+                    } else {
+                        window.__GHOSTIFY_SANITIZED_WORKER_MESSAGES__ = (window.__GHOSTIFY_SANITIZED_WORKER_MESSAGES__ || 0) + 1;
+                    }
+                    tracePostMessageOutcome(kind, blockType, 'sanitize_queue_send', message, text);
+                    return forwardSanitizedPostMessage(originalPostMessage, this, sanitizedQueueSend.value, transferSafe);
+                }
+            }
 
             if (blockType) {
                 if (blockType === 'MSG_SEEN' && (isMessengerDotCom || isFacebookDotCom || isFacebookMessengerProxy)) {
@@ -1364,6 +1387,16 @@ import {
                     }
 
                     if (hasQueueRoutedSendTask) {
+                        if (hasQueueRoutedGroupSendTask) {
+                            if (isQueueSendPrivacyBlockCausedOnlyByMessageContent(message, blockType)) {
+                                window.__GHOSTIFY_FACEBOOK_UNSAFE_BLOCKS_SKIPPED__ = (window.__GHOSTIFY_FACEBOOK_UNSAFE_BLOCKS_SKIPPED__ || 0) + 1;
+                                tracePostMessageOutcome(kind, blockType, 'queue_send_content_forward', message, text);
+                                return originalPostMessage.apply(this, arguments);
+                            }
+                            window.__GHOSTIFY_BLOCKED_WORKER_MESSAGES__ = (window.__GHOSTIFY_BLOCKED_WORKER_MESSAGES__ || 0) + 1;
+                            tracePostMessageOutcome(kind, blockType, 'drop_unsanitized_queue_group_send', message, text);
+                            return undefined;
+                        }
                         window.__GHOSTIFY_FACEBOOK_UNSAFE_BLOCKS_SKIPPED__ = (window.__GHOSTIFY_FACEBOOK_UNSAFE_BLOCKS_SKIPPED__ || 0) + 1;
                         tracePostMessageOutcome(kind, blockType, 'queue_send_forward', message, text);
                         return originalPostMessage.apply(this, arguments);
@@ -1817,6 +1850,32 @@ import {
         }
     }
 
+    function containsQueueRoutedMessengerGroupSendTask(value, depth = 0) {
+        if (!value || depth > 6 || isBinaryPayload(value)) return false;
+        if (Array.isArray(value)) {
+            return value.some(item => containsQueueRoutedMessengerGroupSendTask(item, depth + 1));
+        }
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (!trimmed || (trimmed[0] !== '{' && trimmed[0] !== '[')) return false;
+            try {
+                return containsQueueRoutedMessengerGroupSendTask(JSON.parse(trimmed), depth + 1);
+            } catch (e) {
+                return false;
+            }
+        }
+        if (typeof value !== 'object') return false;
+        if (isQueueRoutedMessengerGroupSendTask(value)) return true;
+
+        try {
+            return Object.keys(value).some(key =>
+                containsQueueRoutedMessengerGroupSendTask(value[key], depth + 1)
+            );
+        } catch (e) {
+            return false;
+        }
+    }
+
     function isQueueRoutedMessengerSendTask(value) {
         if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
         const fields = normalizedBridgeFields(value);
@@ -1827,7 +1886,7 @@ import {
         if (!payload) return false;
         const payloadFields = normalizedBridgeFields(payload);
         const sendType = payloadFields.sendtype;
-        if (!(typeof sendType === 'number' && Number.isFinite(sendType) && sendType > 0)) return false;
+        if (!isPositiveMessengerSendType(sendType)) return false;
 
         const hasClientMessageId = [
             'offlinethreadingid',
@@ -1856,6 +1915,29 @@ import {
         return hasClientMessageId && hasMessagePayload;
     }
 
+    function isQueueRoutedMessengerGroupSendTask(value) {
+        if (!isQueueRoutedMessengerSendTask(value)) return false;
+        const fields = normalizedBridgeFields(value);
+        const payload = parseBridgeObject(fields.payload);
+        if (!payload) return false;
+        const payloadFields = normalizedBridgeFields(payload);
+        const syncGroup = payloadFields.syncgroup;
+        const hasDirectRecipient = [
+            'otheruserid',
+            'otheruserfbid',
+            'recipientid',
+            'targetid'
+        ].some(key => payloadFields[key] != null && String(payloadFields[key]).length > 0);
+        return isPositiveMessengerSendType(syncGroup) && !hasDirectRecipient;
+    }
+
+    function isPositiveMessengerSendType(value) {
+        if (typeof value === 'number') return Number.isFinite(value) && value > 0;
+        if (typeof value !== 'string') return false;
+        const normalized = value.trim();
+        return /^\d+$/.test(normalized) && Number(normalized) > 0;
+    }
+
     function normalizedBridgeFields(value) {
         const fields = {};
         try {
@@ -1878,6 +1960,9 @@ import {
     }
 
     function sanitizeQueueRoutedSendReadMetadata(task) {
+        if (!window.__ghostify_shouldBlockMessengerSeen()) {
+            return { value: task, changed: false, blockedAll: false };
+        }
         let payloadKey;
         try {
             payloadKey = Object.keys(task).find(key => normalizeBridgeKey(key) === 'payload');
@@ -1890,14 +1975,45 @@ import {
         const payload = parseBridgeObject(rawPayload);
         if (!payload) return { value: task, changed: false, blockedAll: false };
 
-        const sanitized = sanitizeQueueSendPayloadReadMetadata(payload);
-        if (!sanitized.changed) return { value: task, changed: false, blockedAll: false };
+        let clone = Object.assign({}, task);
+        let changed = false;
+        if (typeof rawPayload === 'string') {
+            const sanitizedSource = sanitizeJsonTaskBatchStringSource(
+                rawPayload,
+                candidate => {
+                    const sanitized = sanitizeQueueSendPayloadReadMetadata(candidate);
+                    return {
+                        value: sanitized.value,
+                        changed: sanitized.changed,
+                        blockedAll: false
+                    };
+                }
+            );
+            if (sanitizedSource.changed && !sanitizedSource.blockedAll && typeof sanitizedSource.value === 'string') {
+                clone[payloadKey] = sanitizedSource.value;
+                changed = true;
+            }
+        } else {
+            const sanitized = sanitizeQueueSendPayloadReadMetadata(payload);
+            if (sanitized.changed) {
+                clone[payloadKey] = sanitized.value;
+                changed = true;
+            }
+        }
 
-        const clone = Object.assign({}, task);
-        clone[payloadKey] = typeof rawPayload === 'string'
-            ? JSON.stringify(sanitized.value)
-            : sanitized.value;
-        return { value: clone, changed: true, blockedAll: false };
+        const envelope = {};
+        for (const key of Object.keys(clone)) {
+            if (key !== payloadKey) envelope[key] = clone[key];
+        }
+        const sanitizedEnvelope = sanitizeQueueSendPayloadReadMetadata(envelope);
+        if (sanitizedEnvelope.changed) {
+            clone = Object.assign({}, sanitizedEnvelope.value, {
+                [payloadKey]: clone[payloadKey]
+            });
+            changed = true;
+        }
+
+        return { value: changed ? clone : task, changed, blockedAll: false };
     }
 
     function sanitizeQueueSendPayloadReadMetadata(value, depth = 0) {
@@ -1919,6 +2035,10 @@ import {
         for (const key of Object.keys(value)) {
             const child = value[key];
             const normalizedKey = normalizeBridgeKey(key);
+            if (isQueueSendMessageContentKey(normalizedKey)) {
+                clone[key] = child;
+                continue;
+            }
             if (isReadReceiptSendFlagKey(normalizedKey)) {
                 const truthy = isTruthyPrivacyValue(child);
                 clone[key] = truthy ? false : child;
@@ -1942,6 +2062,59 @@ import {
             changed = changed || sanitized.changed;
         }
         return { value: changed ? clone : value, changed };
+    }
+
+    function isQueueSendMessageContentKey(key) {
+        return [
+            'text',
+            'body',
+            'attachment',
+            'sticker',
+            'media',
+            'encryptedmessage',
+            'encryptedpayload',
+            'encryptedblob',
+            'encryptedcontent',
+            'ciphertext',
+            'reaction',
+            'messagereaction',
+            'emoji',
+            'quicklike'
+        ].includes(key);
+    }
+
+    function isQueueSendPrivacyBlockCausedOnlyByMessageContent(value, blockType) {
+        const redacted = redactQueueSendMessageContentForMatch(value);
+        const text = stringifyForMatch(redacted).toLowerCase();
+        if (blockType === 'MSG_TYPING') return !shouldBlockTypingText(text);
+        if (blockType === 'MSG_SEEN') return !shouldBlockSeenText(text);
+        return false;
+    }
+
+    function redactQueueSendMessageContentForMatch(value, depth = 0) {
+        if (!value || depth > 8 || isBinaryPayload(value)) return value;
+        if (Array.isArray(value)) {
+            return value.map(item => redactQueueSendMessageContentForMatch(item, depth + 1));
+        }
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (!trimmed || (trimmed[0] !== '{' && trimmed[0] !== '[')) return value;
+            try {
+                return redactQueueSendMessageContentForMatch(JSON.parse(trimmed), depth + 1);
+            } catch (e) {
+                return value;
+            }
+        }
+        if (typeof value !== 'object') return value;
+
+        const clone = {};
+        for (const key of Object.keys(value)) {
+            const normalizedKey = normalizeBridgeKey(key);
+            clone[key] = normalizedKey === 'message' || isQueueSendMessageContentKey(normalizedKey)
+                ? '[message-content]'
+                : redactQueueSendMessageContentForMatch(value[key], depth + 1);
+        }
+        return clone;
     }
 
     function tracePostMessageOutcome(kind, blockType, outcome, message, text) {

--- a/src/utils/binary-json.js
+++ b/src/utils/binary-json.js
@@ -218,10 +218,27 @@ export function sanitizeFramedJsonTaskBatchBinary(value, sanitizer) {
                 retainedTasks.push(rawTask);
                 continue;
             }
-            if (!sanitized.blockedAll || !Array.isArray(sanitized.value) || sanitized.value.length !== 0) {
+
+            changed = true;
+            if (sanitized.blockedAll) {
+                if (!Array.isArray(sanitized.value) || sanitized.value.length !== 0) {
+                    return unchanged(value);
+                }
+                continue;
+            }
+
+            if (!Array.isArray(sanitized.value) || sanitized.value.length !== 1) {
                 return unchanged(value);
             }
-            changed = true;
+
+            const rewrittenTask = rewriteJsonValueSource(
+                rawTask,
+                task,
+                sanitized.value[0],
+                0
+            );
+            if (typeof rewrittenTask !== 'string') return unchanged(value);
+            retainedTasks.push(rewrittenTask);
         }
         if (!changed || retainedTasks.length === 0) return unchanged(value, changed);
 
@@ -259,7 +276,7 @@ function findFramedTaskEnvelopeSource(text) {
         const tasksSpan = findTopLevelPropertyValueSpan(innerSource, 'tasks');
         if (!tasksSpan || innerSource[tasksSpan.start] !== '[') continue;
         const rawTasks = splitJsonArrayElements(innerSource.slice(tasksSpan.start, tasksSpan.end));
-        if (!rawTasks || rawTasks.length < 2) continue;
+        if (!rawTasks || rawTasks.length === 0) continue;
 
         return {
             prefix,

--- a/src/utils/network.js
+++ b/src/utils/network.js
@@ -875,6 +875,362 @@ function hasSerializedFieldValue(str, field, value) {
     ]);
 }
 
+function normalizeMessengerPayloadKey(key) {
+    return String(key || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+function normalizedMessengerPayloadFields(value) {
+    const fields = {};
+    try {
+        for (const key of Object.keys(value || {})) {
+            fields[normalizeMessengerPayloadKey(key)] = value[key];
+        }
+    } catch (e) { }
+    return fields;
+}
+
+function parseMessengerPayloadObject(value) {
+    if (value && typeof value === 'object' && !Array.isArray(value)) return value;
+    if (typeof value !== 'string') return null;
+    try {
+        const parsed = JSON.parse(value);
+        return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+    } catch (e) {
+        return null;
+    }
+}
+
+function isPositiveMessengerSendType(value) {
+    if (typeof value === 'number') return Number.isFinite(value) && value > 0;
+    if (typeof value !== 'string') return false;
+    const normalized = value.trim();
+    return /^\d+$/.test(normalized) && Number(normalized) > 0;
+}
+
+function getQueueRoutedMessengerSendTask(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+    const fields = normalizedMessengerPayloadFields(value);
+    if (String(fields.label || '') !== '46') return null;
+    if (typeof fields.queuename !== 'string' || !fields.queuename.trim()) return null;
+
+    const payloadKey = Object.keys(value).find(key => normalizeMessengerPayloadKey(key) === 'payload');
+    if (!payloadKey) return null;
+    const rawPayload = value[payloadKey];
+    const payload = parseMessengerPayloadObject(rawPayload);
+    if (!payload) return null;
+
+    const payloadFields = normalizedMessengerPayloadFields(payload);
+    const sendType = payloadFields.sendtype;
+    if (!isPositiveMessengerSendType(sendType)) return null;
+
+    const hasClientMessageId = [
+        'offlinethreadingid',
+        'clientmessageid',
+        'clientmutationid',
+        'otid'
+    ].some(key => payloadFields[key] != null && String(payloadFields[key]).length > 0);
+    const hasMessagePayload = [
+        'message',
+        'text',
+        'body',
+        'attachment',
+        'sticker',
+        'media',
+        'encryptedmessage',
+        'encryptedpayload',
+        'encryptedblob',
+        'encryptedcontent',
+        'ciphertext',
+        'reaction',
+        'messagereaction',
+        'emoji',
+        'quicklike'
+    ].some(key => payloadFields[key] != null);
+
+    return hasClientMessageId && hasMessagePayload
+        ? { payloadKey, rawPayload, payload }
+        : null;
+}
+
+function isNetworkReadReceiptSendFlagKey(key) {
+    return key === 'shouldsendreadreceipt' ||
+        key === 'sendreadreceipt' ||
+        key === 'sendreadreceipts' ||
+        key === 'sendreadreceiptflag' ||
+        key === 'readreceiptenabled';
+}
+
+function isNetworkReadReceiptMutationKey(key) {
+    return key === 'lssendreadreceipt' ||
+        key === 'readreceiptmutation' ||
+        key === 'sendreadreceiptmutation';
+}
+
+function isNetworkReadWatermarkKey(key) {
+    return key === 'lastreadwatermark' ||
+        key === 'lastreadwatermarkts' ||
+        key === 'lastseentimems' ||
+        key === 'readwatermark' ||
+        key === 'watermarktimestamp';
+}
+
+const NETWORK_MESSAGE_CONTENT_KEYS = new Set([
+    'text',
+    'body',
+    'attachment',
+    'sticker',
+    'media',
+    'encryptedmessage',
+    'encryptedpayload',
+    'encryptedblob',
+    'encryptedcontent',
+    'ciphertext',
+    'reaction',
+    'messagereaction',
+    'emoji',
+    'quicklike'
+]);
+
+function isNetworkMessageContentKey(key) {
+    return NETWORK_MESSAGE_CONTENT_KEYS.has(key);
+}
+
+function isLikelyNetworkReadWatermarkValue(value) {
+    if (typeof value === 'number') return Number.isFinite(value) && value >= 1000000000;
+    if (typeof value === 'string') return /^\d{10,}$/.test(value.trim());
+    return false;
+}
+
+function safeNetworkReadWatermarkValue(value) {
+    const text = String(value).trim();
+    const safe = `1${'0'.repeat(Math.max(0, text.length - 1))}`;
+    return typeof value === 'number' ? Number(safe) : safe;
+}
+
+function isTruthyNetworkPrivacyValue(value) {
+    if (value === true || value === 1) return true;
+    if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        return normalized === 'true' || normalized === '1';
+    }
+    return !!(value && typeof value === 'object');
+}
+
+function sanitizeQueueSendPayloadReadMetadata(value, depth = 0) {
+    if (!value || depth > 6 || typeof value !== 'object') {
+        return { value, changed: false };
+    }
+    if (Array.isArray(value)) {
+        let changed = false;
+        const next = value.map(item => {
+            const sanitized = sanitizeQueueSendPayloadReadMetadata(item, depth + 1);
+            changed = changed || sanitized.changed;
+            return sanitized.value;
+        });
+        return { value: changed ? next : value, changed };
+    }
+
+    let changed = false;
+    const clone = {};
+    for (const key of Object.keys(value)) {
+        const child = value[key];
+        const normalizedKey = normalizeMessengerPayloadKey(key);
+        if (isNetworkMessageContentKey(normalizedKey)) {
+            clone[key] = child;
+            continue;
+        }
+        if (isNetworkReadReceiptSendFlagKey(normalizedKey)) {
+            const truthy = isTruthyNetworkPrivacyValue(child);
+            clone[key] = truthy ? false : child;
+            changed = changed || truthy;
+            continue;
+        }
+        if (isNetworkReadReceiptMutationKey(normalizedKey)) {
+            const truthy = isTruthyNetworkPrivacyValue(child);
+            clone[key] = truthy ? null : child;
+            changed = changed || truthy;
+            continue;
+        }
+        if (isNetworkReadWatermarkKey(normalizedKey) && isLikelyNetworkReadWatermarkValue(child)) {
+            clone[key] = safeNetworkReadWatermarkValue(child);
+            changed = changed || clone[key] !== child;
+            continue;
+        }
+
+        const sanitized = sanitizeQueueSendPayloadReadMetadata(child, depth + 1);
+        clone[key] = sanitized.value;
+        changed = changed || sanitized.changed;
+    }
+    return { value: changed ? clone : value, changed };
+}
+
+function sanitizeQueueRoutedMessengerSendTask(value) {
+    const task = getQueueRoutedMessengerSendTask(value);
+    if (!task || !SETTINGS.msgSeen || isKilled('msgSeen')) {
+        return { value, changed: false, blockedAll: false };
+    }
+
+    let clone = Object.assign({}, value);
+    let changed = false;
+    if (typeof task.rawPayload === 'string') {
+        const sanitizedSource = sanitizeJsonTaskBatchStringSource(
+            task.rawPayload,
+            candidate => {
+                const sanitized = sanitizeQueueSendPayloadReadMetadata(candidate);
+                return {
+                    value: sanitized.value,
+                    changed: sanitized.changed,
+                    blockedAll: false
+                };
+            }
+        );
+        if (sanitizedSource.changed && !sanitizedSource.blockedAll && typeof sanitizedSource.value === 'string') {
+            clone[task.payloadKey] = sanitizedSource.value;
+            changed = true;
+        }
+    } else {
+        const sanitized = sanitizeQueueSendPayloadReadMetadata(task.payload);
+        if (sanitized.changed) {
+            clone[task.payloadKey] = sanitized.value;
+            changed = true;
+        }
+    }
+
+    const envelope = {};
+    for (const key of Object.keys(clone)) {
+        if (key !== task.payloadKey) envelope[key] = clone[key];
+    }
+    const sanitizedEnvelope = sanitizeQueueSendPayloadReadMetadata(envelope);
+    if (sanitizedEnvelope.changed) {
+        clone = Object.assign({}, sanitizedEnvelope.value, {
+            [task.payloadKey]: clone[task.payloadKey]
+        });
+        changed = true;
+    }
+
+    return { value: changed ? clone : value, changed, blockedAll: false };
+}
+
+function parseMessengerStructuredText(value) {
+    const source = String(value || '').trim();
+    if (!source) return null;
+    const candidates = [source];
+    const nullIndex = source.lastIndexOf('\u0000');
+    if (nullIndex >= 0) candidates.unshift(source.slice(nullIndex + 1).trim());
+
+    for (const candidate of candidates) {
+        if (!candidate || (candidate[0] !== '{' && candidate[0] !== '[')) continue;
+        try {
+            return JSON.parse(candidate);
+        } catch (e) {
+            const isolated = isolateFirstMessengerJsonValue(candidate);
+            if (!isolated) continue;
+            try {
+                return JSON.parse(isolated);
+            } catch (parseError) { }
+        }
+    }
+    return null;
+}
+
+function isolateFirstMessengerJsonValue(source) {
+    const first = source[0];
+    if (first !== '{' && first !== '[') return null;
+    const stack = [first];
+    let inString = false;
+    let escaped = false;
+
+    for (let index = 1; index < source.length; index += 1) {
+        const char = source[index];
+        if (inString) {
+            if (escaped) escaped = false;
+            else if (char === '\\') escaped = true;
+            else if (char === '"') inString = false;
+            continue;
+        }
+        if (char === '"') {
+            inString = true;
+            continue;
+        }
+        if (char === '{' || char === '[') stack.push(char);
+        else if (char === '}' || char === ']') {
+            const open = stack.pop();
+            if ((open === '{' && char !== '}') || (open === '[' && char !== ']')) return null;
+            if (stack.length === 0) return source.slice(0, index + 1);
+        }
+    }
+    return null;
+}
+
+function hasUnsafeNetworkPrivacyMetadata(value, depth = 0) {
+    if (!value || depth > 8) return false;
+    if (typeof value === 'string') {
+        const parsed = parseMessengerStructuredText(value);
+        return parsed ? hasUnsafeNetworkPrivacyMetadata(parsed, depth + 1) : false;
+    }
+    if (Array.isArray(value)) {
+        return value.some(item => hasUnsafeNetworkPrivacyMetadata(item, depth + 1));
+    }
+    if (typeof value !== 'object') return false;
+
+    const fields = normalizedMessengerPayloadFields(value);
+    const label = normalizeMessengerPayloadKey(fields.label);
+    if (label === '6' || label === '21') return true;
+
+    for (const key of Object.keys(value)) {
+        const child = value[key];
+        const normalizedKey = normalizeMessengerPayloadKey(key);
+        if (isNetworkMessageContentKey(normalizedKey)) continue;
+        if ((isNetworkReadReceiptSendFlagKey(normalizedKey) || isNetworkReadReceiptMutationKey(normalizedKey)) &&
+            isTruthyNetworkPrivacyValue(child)) {
+            return true;
+        }
+        if (isNetworkReadWatermarkKey(normalizedKey) && isLikelyNetworkReadWatermarkValue(child) &&
+            safeNetworkReadWatermarkValue(child) !== child) {
+            return true;
+        }
+        if (hasUnsafeNetworkPrivacyMetadata(child, depth + 1)) return true;
+    }
+    return false;
+}
+
+function inspectQueueRoutedMessengerEnvelope(value, depth = 0, state = { send: false, unsafe: false }) {
+    if (!value || depth > 8 || state.unsafe) return state;
+    if (typeof value === 'string') {
+        const parsed = parseMessengerStructuredText(value);
+        if (parsed) inspectQueueRoutedMessengerEnvelope(parsed, depth + 1, state);
+        return state;
+    }
+    if (Array.isArray(value)) {
+        for (const item of value) inspectQueueRoutedMessengerEnvelope(item, depth + 1, state);
+        return state;
+    }
+    if (typeof value !== 'object') return state;
+
+    const task = getQueueRoutedMessengerSendTask(value);
+    if (task) {
+        state.send = true;
+        state.unsafe = hasUnsafeNetworkPrivacyMetadata(value, depth + 1);
+        return state;
+    }
+
+    if (hasUnsafeNetworkPrivacyMetadata(value, depth)) {
+        state.unsafe = true;
+        return state;
+    }
+    for (const child of Object.values(value)) {
+        inspectQueueRoutedMessengerEnvelope(child, depth + 1, state);
+    }
+    return state;
+}
+
+function hasSafeQueueRoutedMessengerSendIntent(str) {
+    const parsed = parseMessengerStructuredText(str);
+    if (!parsed) return false;
+    const state = inspectQueueRoutedMessengerEnvelope(parsed);
+    return state.send && !state.unsafe;
+}
+
 function isMessengerSendWithBundledReadWatermark(str) {
     if (!str.includes('send_type')) return false;
     if (!hasReadReceiptWatermarkContext(str)) return false;
@@ -886,7 +1242,9 @@ function isMessengerSendWithBundledReadWatermark(str) {
 function hasMessengerMessageSendIntent(str) {
     const text = String(str || '');
     const matchText = text.includes('\\') ? `${text} ${text.replace(/\\/g, '')}` : text;
-    if (!hasMessengerThreadContext(matchText)) return false;
+    const hasQueueRoutedSend = hasSafeQueueRoutedMessengerSendIntent(text);
+    if (!hasMessengerThreadContext(matchText) && !hasQueueRoutedSend) return false;
+    if (hasQueueRoutedSend) return true;
 
     const hasSendOperationName = includesAny(matchText, [
         'send_message',
@@ -1196,12 +1554,6 @@ function sanitizeMessengerNetworkValue(
         const next = [];
 
         for (const item of value) {
-            const itemText = decode(item).toLowerCase();
-            if (privacyOnlyPredicate(itemText, urlString, options)) {
-                changed = true;
-                continue;
-            }
-
             const sanitizedItem = sanitizeMessengerNetworkValue(
                 item,
                 urlString,
@@ -1210,6 +1562,12 @@ function sanitizeMessengerNetworkValue(
                 privacyOnlyPredicate
             );
             if (sanitizedItem.blockedAll) {
+                changed = true;
+                continue;
+            }
+
+            const itemText = decode(sanitizedItem.value).toLowerCase();
+            if (privacyOnlyPredicate(itemText, urlString, options)) {
                 changed = true;
                 continue;
             }
@@ -1226,6 +1584,9 @@ function sanitizeMessengerNetworkValue(
     }
 
     if (typeof value === 'object') {
+        const queueRoutedSend = sanitizeQueueRoutedMessengerSendTask(value);
+        if (queueRoutedSend.changed) return queueRoutedSend;
+
         const ownText = decode(value).toLowerCase();
         if (isMessengerNormalThreadListPaginationTask(ownText)) {
             return { value, changed: false, blockedAll: false };

--- a/test/messenger-send-stability.test.js
+++ b/test/messenger-send-stability.test.js
@@ -1199,10 +1199,10 @@ function decodeBridgeBytes(value) {
     return new TextDecoder().decode(new Uint8Array(value.buffer, value.byteOffset, value.byteLength));
 }
 
-function decodeFacebookFramedTasks(value) {
+function decodeFacebookFramedTasks(value, prefix = facebookFramePrefix) {
     const text = decodeBridgeBytes(value);
-    assert.ok(text.startsWith(facebookFramePrefix), 'Facebook realtime frame prefix must stay byte-for-byte intact');
-    const outer = JSON.parse(text.slice(facebookFramePrefix.length));
+    assert.ok(text.startsWith(prefix), 'Facebook realtime frame prefix must stay byte-for-byte intact');
+    const outer = JSON.parse(text.slice(prefix.length));
     return { outer, inner: JSON.parse(outer.payload) };
 }
 
@@ -1582,7 +1582,7 @@ function testFacebookMiniChatSecureSendWithAlternateTargetsIsForwarded() {
     assert.strictEqual(forwarded.tasks[0].payload.message.text, '1');
 }
 
-function testFacebookMiniChatMixedSendTypingBridgeFrameDoesNotEnterTypingSanitizer() {
+function testFacebookMiniChatQueueDirectSendSanitizesBundledPrivacy() {
     const context = makeMessengerPatchPage({}, {
         hostname: 'www.facebook.com',
         pathname: '/',
@@ -1598,7 +1598,10 @@ function testFacebookMiniChatMixedSendTypingBridgeFrameDoesNotEnterTypingSanitiz
                 other_user_id: 'redacted-user',
                 offline_threading_id: 'redacted-offline-id',
                 send_type: 1,
-                message: { text: 'a' }
+                message: { text: 'a' },
+                sync_group: 104,
+                should_send_read_receipt: true,
+                last_read_watermark_ts: 1779530000000
             })
         }, {
             label: 'sendChatStateFromComposer',
@@ -1615,19 +1618,90 @@ function testFacebookMiniChatMixedSendTypingBridgeFrameDoesNotEnterTypingSanitiz
     assert.strictEqual(
         outcome.result,
         'worker-sent',
-        'Facebook mixed send/typing bridge frames must forward instead of entering the typing sanitizer'
+        'Facebook queue-routed direct sends must survive bundled privacy sanitization'
     );
     assert.strictEqual(outcome.postCount, 1);
     assert.strictEqual(outcome.blocked, 0);
     assert.strictEqual(
-        outcome.sanitized,
-        0,
-        'mixed send/typing frames should not be rewritten when preserving the send requires native frame shape'
+        outcome.sanitizedSeen,
+        1,
+        'direct sends must remove bundled Seen metadata without dropping the message'
     );
     const forwarded = parseForwardedMessage(outcome.post);
-    assert.strictEqual(forwarded.tasks.length, 2);
+    assert.strictEqual(forwarded.tasks.length, 1);
     assert.strictEqual(forwarded.tasks[0].label, '46');
-    assert.strictEqual(forwarded.tasks[1].label, 'sendChatStateFromComposer');
+    const payload = JSON.parse(forwarded.tasks[0].payload);
+    assert.strictEqual(payload.other_user_id, 'redacted-user');
+    assert.strictEqual(payload.message.text, 'a');
+    assert.strictEqual(payload.should_send_read_receipt, false);
+    assert.strictEqual(payload.last_read_watermark_ts, SAFE_READ_WATERMARK);
+    assert.strictEqual(JSON.parse(message.tasks[0].payload).should_send_read_receipt, true);
+
+    const portContext = makeMessengerPatchPage({}, {
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/',
+        facebookMiniChatOpen: true
+    });
+    const port = portOutcome(portContext, message);
+    assert.strictEqual(port.result, 'port-sent');
+    assert.strictEqual(port.postCount, 1);
+    assert.strictEqual(port.blocked, 0);
+    assert.strictEqual(port.sanitizedSeen, 1);
+    assert.strictEqual(port.post.message.tasks.length, 1);
+    const portPayload = JSON.parse(port.post.message.tasks[0].payload);
+    assert.strictEqual(portPayload.other_user_id, 'redacted-user');
+    assert.strictEqual(portPayload.should_send_read_receipt, false);
+    assert.strictEqual(portPayload.last_read_watermark_ts, SAFE_READ_WATERMARK);
+
+    const seenDisabled = workerOutcome(makeMessengerPatchPage({
+        msgSeen: false,
+        msgTyping: true
+    }, {
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/',
+        facebookMiniChatOpen: true
+    }), message);
+    assert.strictEqual(seenDisabled.result, 'worker-sent');
+    assert.strictEqual(seenDisabled.postCount, 1);
+    assert.strictEqual(seenDisabled.sanitized, 1);
+    assert.strictEqual(seenDisabled.sanitizedSeen, 0);
+    assert.strictEqual(seenDisabled.post.message.tasks.length, 1);
+    const seenDisabledPayload = JSON.parse(seenDisabled.post.message.tasks[0].payload);
+    assert.strictEqual(seenDisabledPayload.should_send_read_receipt, true);
+    assert.strictEqual(seenDisabledPayload.last_read_watermark_ts, 1779530000000);
+
+    const typingDisabled = workerOutcome(makeMessengerPatchPage({
+        msgSeen: true,
+        msgTyping: false
+    }, {
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/',
+        facebookMiniChatOpen: true
+    }), message);
+    assert.strictEqual(typingDisabled.result, 'worker-sent');
+    assert.strictEqual(typingDisabled.postCount, 1);
+    assert.strictEqual(typingDisabled.sanitizedSeen, 1);
+    assert.strictEqual(typingDisabled.post.message.tasks.length, 2);
+    const typingDisabledPayload = JSON.parse(typingDisabled.post.message.tasks[0].payload);
+    assert.strictEqual(typingDisabledPayload.should_send_read_receipt, false);
+    assert.strictEqual(typingDisabledPayload.last_read_watermark_ts, SAFE_READ_WATERMARK);
+    assert.strictEqual(typingDisabled.post.message.tasks[1].label, 'sendChatStateFromComposer');
+
+    const protectionsDisabled = workerOutcome(makeMessengerPatchPage({
+        msgSeen: false,
+        msgTyping: false
+    }, {
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/',
+        facebookMiniChatOpen: true
+    }), message);
+    assert.strictEqual(protectionsDisabled.result, 'worker-sent');
+    assert.strictEqual(protectionsDisabled.postCount, 1);
+    assert.strictEqual(protectionsDisabled.post.message, message);
 }
 
 function testFacebookGroupSendWithQueueOnlyTargetPreservesSendAndRemovesTyping() {
@@ -1679,20 +1753,32 @@ function testFacebookGroupSendWithQueueOnlyTargetPreservesSendAndRemovesTyping()
         href: 'https://www.facebook.com/',
         facebookMiniChatOpen: true
     });
+    const workerThreadId = '7466158453245588004';
+    const workerPayload = JSON.stringify({
+        thread_id: '__GHOSTIFY_WORKER_THREAD_ID__',
+        offline_threading_id: 'redacted-offline-id',
+        send_type: '1',
+        message: {
+            text: 'group message',
+            metadata: {
+                should_send_read_receipt: true,
+                last_read_watermark_ts: 1779530000000
+            }
+        },
+        sync_group: 104,
+        last_read_watermark_ts: 1779530000000,
+        should_send_read_receipt: true
+    }).replace('"__GHOSTIFY_WORKER_THREAD_ID__"', workerThreadId);
     const seenMessage = {
         issue_new_task: true,
         tasks: [{
             label: '46',
             queue_name: 'redacted-group-thread',
             task_id: 416,
-            payload: JSON.stringify({
-                offline_threading_id: 'redacted-offline-id',
-                send_type: 1,
-                message: { text: 'group message' },
-                sync_group: 104,
-                last_read_watermark_ts: 1779530000000,
-                should_send_read_receipt: true
-            })
+            should_send_read_receipt: true,
+            last_read_watermark_ts: 1779530000000,
+            readReceiptMutation: { should_send_read_receipt: true },
+            payload: workerPayload
         }]
     };
     const seenOutcome = workerOutcome(seenContext, seenMessage);
@@ -1710,11 +1796,105 @@ function testFacebookGroupSendWithQueueOnlyTargetPreservesSendAndRemovesTyping()
     assert.strictEqual(seenOutcome.post.message.tasks[0].label, '46');
     assert.strictEqual(seenOutcome.post.message.tasks[0].queue_name, 'redacted-group-thread');
     assert.strictEqual(seenOutcome.post.message.tasks[0].task_id, 416);
-    const sanitizedSendPayload = JSON.parse(seenOutcome.post.message.tasks[0].payload);
+    assert.strictEqual(seenOutcome.post.message.tasks[0].should_send_read_receipt, false);
+    assert.strictEqual(seenOutcome.post.message.tasks[0].last_read_watermark_ts, SAFE_READ_WATERMARK);
+    assert.strictEqual(seenOutcome.post.message.tasks[0].readReceiptMutation, null);
+    const sanitizedWorkerPayloadSource = seenOutcome.post.message.tasks[0].payload;
+    assert.match(sanitizedWorkerPayloadSource, new RegExp(`"thread_id":${workerThreadId}(?:,|})`));
+    assert.doesNotMatch(sanitizedWorkerPayloadSource, /"thread_id":7466158453245588000(?:,|})/);
+    const sanitizedSendPayload = JSON.parse(sanitizedWorkerPayloadSource);
     assert.strictEqual(sanitizedSendPayload.message.text, 'group message');
+    assert.strictEqual(sanitizedSendPayload.message.metadata.should_send_read_receipt, false);
+    assert.strictEqual(sanitizedSendPayload.message.metadata.last_read_watermark_ts, SAFE_READ_WATERMARK);
     assert.strictEqual(sanitizedSendPayload.offline_threading_id, 'redacted-offline-id');
+    assert.strictEqual(sanitizedSendPayload.send_type, '1');
     assert.strictEqual(sanitizedSendPayload.should_send_read_receipt, false);
     assert.strictEqual(sanitizedSendPayload.last_read_watermark_ts, SAFE_READ_WATERMARK);
+    assert.strictEqual(seenMessage.tasks[0].should_send_read_receipt, true);
+    assert.strictEqual(seenMessage.tasks[0].last_read_watermark_ts, 1779530000000);
+    assert.strictEqual(seenMessage.tasks[0].payload, workerPayload);
+
+    const portContext = makeMessengerPatchPage({}, {
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/',
+        facebookMiniChatOpen: true
+    });
+    const portSeenOutcome = portOutcome(portContext, seenMessage);
+    assert.strictEqual(portSeenOutcome.result, 'port-sent');
+    assert.strictEqual(portSeenOutcome.postCount, 1);
+    assert.strictEqual(portSeenOutcome.blocked, 0);
+    assert.strictEqual(portSeenOutcome.sanitizedSeen, 1);
+    const portTask = portSeenOutcome.post.message.tasks[0];
+    assert.strictEqual(portTask.should_send_read_receipt, false);
+    assert.strictEqual(portTask.last_read_watermark_ts, SAFE_READ_WATERMARK);
+    assert.strictEqual(portTask.readReceiptMutation, null);
+    assert.match(portTask.payload, new RegExp(`"thread_id":${workerThreadId}(?:,|})`));
+    const portPayload = JSON.parse(portTask.payload);
+    assert.strictEqual(portPayload.send_type, '1');
+    assert.strictEqual(portPayload.message.text, 'group message');
+    assert.strictEqual(portPayload.should_send_read_receipt, false);
+
+    const seenDisabledContext = makeMessengerPatchPage({
+        msgSeen: false,
+        msgTyping: true
+    }, {
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/',
+        facebookMiniChatOpen: true
+    });
+    const seenDisabled = workerOutcome(seenDisabledContext, seenMessage);
+    assert.strictEqual(seenDisabled.result, 'worker-sent');
+    assert.strictEqual(seenDisabled.postCount, 1);
+    assert.strictEqual(seenDisabled.blocked, 0);
+    assert.strictEqual(seenDisabled.sanitized, 0);
+    assert.strictEqual(seenDisabled.sanitizedSeen, 0);
+    assert.strictEqual(
+        seenDisabled.post.message,
+        seenMessage,
+        'disabling Hide Seen must preserve the exact queue-routed send while Hide Typing remains enabled'
+    );
+    assert.strictEqual(seenMessage.tasks[0].should_send_read_receipt, true);
+    assert.strictEqual(JSON.parse(seenMessage.tasks[0].payload).should_send_read_receipt, true);
+}
+
+function testFacebookQueueOnlyGroupUserContentDoesNotTriggerPrivacyBlock() {
+    const privacyLikeText = '{"should_send_read_receipt":true,"last_read_watermark_ts":1779530000000}';
+    const message = {
+        issue_new_task: true,
+        tasks: [{
+            label: '46',
+            queue_name: 'redacted-group-thread',
+            task_id: 417,
+            payload: JSON.stringify({
+                offline_threading_id: 'redacted-offline-id',
+                send_type: 1,
+                message: { text: privacyLikeText },
+                sync_group: 104
+            })
+        }]
+    };
+    const page = {
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/',
+        facebookMiniChatOpen: true
+    };
+
+    const worker = workerOutcome(makeMessengerPatchPage({}, page), message);
+    assert.strictEqual(worker.result, 'worker-sent');
+    assert.strictEqual(worker.postCount, 1);
+    assert.strictEqual(worker.blocked, 0);
+    assert.strictEqual(worker.post.message, message);
+    assert.strictEqual(JSON.parse(worker.post.message.tasks[0].payload).message.text, privacyLikeText);
+
+    const port = portOutcome(makeMessengerPatchPage({}, page), message);
+    assert.strictEqual(port.result, 'port-sent');
+    assert.strictEqual(port.postCount, 1);
+    assert.strictEqual(port.blocked, 0);
+    assert.strictEqual(port.post.message, message);
+    assert.strictEqual(JSON.parse(port.post.message.tasks[0].payload).message.text, privacyLikeText);
 }
 
 function testFacebookQueueOnlyPrivacyTasksAreNotClassifiedAsSends() {
@@ -1770,6 +1950,321 @@ function testFacebookQueueOnlyPrivacyTasksAreNotClassifiedAsSends() {
     assert.strictEqual(seenOutcome.result, undefined);
     assert.strictEqual(seenOutcome.postCount, 0);
     assert.strictEqual(seenOutcome.blocked, 1);
+}
+
+function testFacebookQueueOnlyGroupSendWithSeenMetadataIsAllowedOnRealtimeWebSocket() {
+    const epochId = '7466158453245588002';
+    const makeSendTask = (payloadOverrides = {}, taskOverrides = {}) => ({
+        failure_count: null,
+        label: '46',
+        payload: JSON.stringify({
+            offline_threading_id: 'redacted-offline-id',
+            send_type: 1,
+            message: { text: 'group message' },
+            sync_group: 104,
+            last_read_watermark_ts: 1779530000000,
+            should_send_read_receipt: true,
+            ...payloadOverrides
+        }),
+        queue_name: 'redacted-group-thread',
+        task_id: 419,
+        ...taskOverrides
+    });
+    const makeFrame = (prefix, tasks = [makeSendTask()]) => {
+        const inner = JSON.stringify({
+            epoch_id: '__GHOSTIFY_EPOCH_ID__',
+            tasks,
+            version_id: '27029912679952307'
+        }).replace('"__GHOSTIFY_EPOCH_ID__"', epochId);
+        return new Uint8Array(Buffer.from(`${prefix}${JSON.stringify({
+            app_id: '2220391788200892',
+            payload: inner,
+            request_id: 183,
+            type: 3
+        })}`, 'utf8'));
+    };
+    const cases = [{
+        label: 'Facebook top frame edge-chat Uint8Array',
+        page: { hostname: 'www.facebook.com', pathname: '/', href: 'https://www.facebook.com/' },
+        url: 'wss://edge-chat.facebook.com/chat?region=redacted',
+        prefix: '{}\r\u0000',
+        asArrayBuffer: false
+    }, {
+        label: 'Facebook top frame lightspeed ArrayBuffer',
+        page: { hostname: 'www.facebook.com', pathname: '/', href: 'https://www.facebook.com/' },
+        url: 'wss://gateway.facebook.com/ws/lightspeed',
+        prefix: facebookFramePrefix,
+        asArrayBuffer: true
+    }, {
+        label: 'Facebook MAW proxy edge-chat Uint8Array',
+        page: {
+            hostname: 'www.fbsbx.com',
+            pathname: '/maw_proxy_page/',
+            href: 'https://www.fbsbx.com/maw_proxy_page/'
+        },
+        url: 'wss://edge-chat.facebook.com/chat?region=redacted',
+        prefix: facebookFramePrefix,
+        asArrayBuffer: false
+    }, {
+        label: 'Facebook MAW proxy lightspeed ArrayBuffer',
+        page: {
+            hostname: 'www.fbsbx.com',
+            pathname: '/maw_proxy_page/',
+            href: 'https://www.fbsbx.com/maw_proxy_page/'
+        },
+        url: 'wss://gateway.facebook.com/ws/lightspeed',
+        prefix: '{}\r\u0000',
+        asArrayBuffer: true
+    }];
+
+    for (const testCase of cases) {
+        const window = makeGhostPage(testCase.page);
+        const frameBytes = makeFrame(testCase.prefix);
+        const originalBytes = Array.from(frameBytes);
+        const frame = testCase.asArrayBuffer
+            ? frameBytes.buffer.slice(frameBytes.byteOffset, frameBytes.byteOffset + frameBytes.byteLength)
+            : frameBytes;
+        const expectedTag = testCase.asArrayBuffer ? '[object ArrayBuffer]' : '[object Uint8Array]';
+        const outcome = websocketSend(window, frame, testCase.url);
+
+        assert.strictEqual(outcome.result, 'sent', `${testCase.label} must leave Sending`);
+        assert.strictEqual(outcome.socket.sent.length, 1, `${testCase.label} must send exactly once`);
+        assert.deepStrictEqual(
+            Array.from(testCase.asArrayBuffer ? new Uint8Array(frame) : frame),
+            originalBytes,
+            `${testCase.label} must not mutate the original frame`
+        );
+
+        const forwarded = outcome.socket.sent[0];
+        assert.strictEqual(Object.prototype.toString.call(forwarded), expectedTag);
+        const { outer, inner } = decodeFacebookFramedTasks(forwarded, testCase.prefix);
+        assert.strictEqual(outer.app_id, '2220391788200892');
+        assert.strictEqual(outer.request_id, 183);
+        assert.strictEqual(outer.type, 3);
+        assert.match(outer.payload, new RegExp(`"epoch_id":${epochId}(?:,|})`));
+        assert.strictEqual(inner.version_id, '27029912679952307');
+        assert.strictEqual(inner.tasks.length, 1);
+
+        const task = inner.tasks[0];
+        assert.strictEqual(task.label, '46');
+        assert.strictEqual(task.queue_name, 'redacted-group-thread');
+        assert.strictEqual(task.task_id, 419);
+        const payload = JSON.parse(task.payload);
+        assert.strictEqual(payload.offline_threading_id, 'redacted-offline-id');
+        assert.strictEqual(payload.send_type, 1);
+        assert.deepStrictEqual(payload.message, { text: 'group message' });
+        assert.strictEqual(payload.sync_group, 104);
+        assert.strictEqual(payload.should_send_read_receipt, false);
+        assert.strictEqual(payload.last_read_watermark_ts, SAFE_READ_WATERMARK);
+    }
+
+    const privacyLikeUserText = '{"should_send_read_receipt":true,"last_read_watermark_ts":1779530000000}';
+    const userTextWindow = makeGhostPage({
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/'
+    });
+    const userText = websocketSend(
+        userTextWindow,
+        makeFrame('{}\r\u0000', [makeSendTask({ message: { text: privacyLikeUserText } })]),
+        'wss://edge-chat.facebook.com/chat?region=redacted'
+    );
+    assert.strictEqual(userText.result, 'sent');
+    const userTextDecoded = decodeFacebookFramedTasks(userText.socket.sent[0], '{}\r\u0000');
+    const userTextPayload = JSON.parse(userTextDecoded.inner.tasks[0].payload);
+    assert.strictEqual(userTextPayload.message.text, privacyLikeUserText);
+    assert.strictEqual(userTextPayload.should_send_read_receipt, false);
+    assert.strictEqual(userTextPayload.last_read_watermark_ts, SAFE_READ_WATERMARK);
+
+    const threadId = '7466158453245588003';
+    const payloadWithLargeThreadId = JSON.stringify({
+        thread_id: '__GHOSTIFY_THREAD_ID__',
+        offline_threading_id: 'redacted-offline-id',
+        send_type: 1,
+        message: { text: 'group message' },
+        sync_group: 104,
+        last_read_watermark_ts: 1779530000000,
+        should_send_read_receipt: true
+    }).replace('"__GHOSTIFY_THREAD_ID__"', threadId);
+    const largeIdWindow = makeGhostPage({
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/'
+    });
+    const largeId = websocketSend(
+        largeIdWindow,
+        makeFrame('{}\r\u0000', [makeSendTask({}, { payload: payloadWithLargeThreadId })]),
+        'wss://edge-chat.facebook.com/chat?region=redacted'
+    );
+    assert.strictEqual(largeId.result, 'sent');
+    const largeIdDecoded = decodeFacebookFramedTasks(largeId.socket.sent[0], '{}\r\u0000');
+    const forwardedPayloadSource = largeIdDecoded.inner.tasks[0].payload;
+    assert.match(forwardedPayloadSource, new RegExp(`"thread_id":${threadId}(?:,|})`));
+    assert.doesNotMatch(forwardedPayloadSource, /"thread_id":7466158453245588000(?:,|})/);
+    const largeIdPayload = JSON.parse(forwardedPayloadSource);
+    assert.strictEqual(largeIdPayload.should_send_read_receipt, false);
+    assert.strictEqual(largeIdPayload.last_read_watermark_ts, SAFE_READ_WATERMARK);
+
+    const directWindow = makeGhostPage({
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/'
+    });
+    const direct = websocketSend(
+        directWindow,
+        makeFrame('{}\r\u0000', [makeSendTask({
+            other_user_id: 'redacted-user',
+            message: {
+                text: 'direct message',
+                metadata: {
+                    should_send_read_receipt: true,
+                    last_read_watermark_ts: 1779530000000
+                }
+            },
+            sync_group: 104
+        })]),
+        'wss://edge-chat.facebook.com/chat?region=redacted'
+    );
+    assert.strictEqual(direct.result, 'sent');
+    assert.strictEqual(direct.socket.sent.length, 1);
+    const directDecoded = decodeFacebookFramedTasks(direct.socket.sent[0], '{}\r\u0000');
+    const directPayload = JSON.parse(directDecoded.inner.tasks[0].payload);
+    assert.strictEqual(directPayload.other_user_id, 'redacted-user');
+    assert.strictEqual(directPayload.message.text, 'direct message');
+    assert.strictEqual(directPayload.message.metadata.should_send_read_receipt, false);
+    assert.strictEqual(directPayload.message.metadata.last_read_watermark_ts, SAFE_READ_WATERMARK);
+    assert.strictEqual(directPayload.should_send_read_receipt, false);
+    assert.strictEqual(directPayload.last_read_watermark_ts, SAFE_READ_WATERMARK);
+
+    const taskMetadataWindow = makeGhostPage({
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/'
+    });
+    const taskMetadata = websocketSend(
+        taskMetadataWindow,
+        makeFrame('{}\r\u0000', [makeSendTask(
+            { send_type: '1' },
+            {
+                should_send_read_receipt: true,
+                last_read_watermark_ts: 1779530000000,
+                readReceiptMutation: { should_send_read_receipt: true }
+            }
+        )]),
+        'wss://edge-chat.facebook.com/chat?region=redacted'
+    );
+    assert.strictEqual(taskMetadata.result, 'sent');
+    assert.strictEqual(taskMetadata.socket.sent.length, 1);
+    const taskMetadataDecoded = decodeFacebookFramedTasks(taskMetadata.socket.sent[0], '{}\r\u0000');
+    const sanitizedTask = taskMetadataDecoded.inner.tasks[0];
+    assert.strictEqual(sanitizedTask.label, '46');
+    assert.strictEqual(sanitizedTask.queue_name, 'redacted-group-thread');
+    assert.strictEqual(sanitizedTask.task_id, 419);
+    assert.strictEqual(sanitizedTask.should_send_read_receipt, false);
+    assert.strictEqual(sanitizedTask.last_read_watermark_ts, SAFE_READ_WATERMARK);
+    assert.strictEqual(sanitizedTask.readReceiptMutation, null);
+    const taskMetadataPayload = JSON.parse(sanitizedTask.payload);
+    assert.strictEqual(taskMetadataPayload.send_type, '1');
+    assert.strictEqual(taskMetadataPayload.message.text, 'group message');
+
+    const invalidCases = [{
+        label: 'missing queue_name',
+        task: (() => {
+            const task = makeSendTask();
+            delete task.queue_name;
+            return task;
+        })()
+    }, {
+        label: 'missing client message id',
+        task: makeSendTask({ offline_threading_id: undefined })
+    }, {
+        label: 'missing message payload',
+        task: makeSendTask({ message: undefined })
+    }, {
+        label: 'read command with misleading send fields',
+        task: makeSendTask({}, { label: 'markThreadAsRead' })
+    }];
+
+    for (const invalidCase of invalidCases) {
+        const window = makeGhostPage({
+            hostname: 'www.facebook.com',
+            pathname: '/',
+            href: 'https://www.facebook.com/'
+        });
+        const outcome = websocketSend(
+            window,
+            makeFrame('{}\r\u0000', [invalidCase.task]),
+            'wss://edge-chat.facebook.com/chat?region=redacted'
+        );
+        assert.strictEqual(outcome.result, undefined, `${invalidCase.label} must not receive the send exemption`);
+        assert.strictEqual(outcome.socket.sent.length, 0);
+    }
+
+    const mixedWindow = makeGhostPage({
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/'
+    });
+    const mixedFrame = makeFrame(facebookFramePrefix, [
+        makeSendTask(),
+        {
+            label: '21',
+            payload: JSON.stringify({
+                thread_id: 'redacted-group-thread',
+                last_read_watermark_ts: 1779530000000,
+                sync_group: 104
+            }),
+            queue_name: 'redacted-group-thread',
+            task_id: 420
+        }
+    ]);
+    const mixed = websocketSend(
+        mixedWindow,
+        mixedFrame,
+        'wss://edge-chat.facebook.com/chat?region=redacted'
+    );
+    assert.strictEqual(mixed.result, 'sent');
+    assert.strictEqual(mixed.socket.sent.length, 1);
+    const mixedDecoded = decodeFacebookFramedTasks(mixed.socket.sent[0], facebookFramePrefix);
+    assert.deepStrictEqual(mixedDecoded.inner.tasks.map(task => task.label), ['46']);
+    const mixedPayload = JSON.parse(mixedDecoded.inner.tasks[0].payload);
+    assert.strictEqual(mixedPayload.should_send_read_receipt, false);
+    assert.strictEqual(mixedPayload.last_read_watermark_ts, SAFE_READ_WATERMARK);
+
+    const disabledWindow = makeGhostPage({
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/'
+    }, { msgSeen: false, msgTyping: true });
+    const disabledFrame = makeFrame('{}\r\u0000');
+    const disabled = websocketSend(
+        disabledWindow,
+        disabledFrame,
+        'wss://edge-chat.facebook.com/chat?region=redacted'
+    );
+    assert.strictEqual(disabled.result, 'sent');
+    assert.strictEqual(disabled.socket.sent[0], disabledFrame);
+    const disabledDecoded = decodeFacebookFramedTasks(disabled.socket.sent[0], '{}\r\u0000');
+    const disabledPayload = JSON.parse(disabledDecoded.inner.tasks[0].payload);
+    assert.strictEqual(disabledPayload.should_send_read_receipt, true);
+    assert.strictEqual(disabledPayload.last_read_watermark_ts, 1779530000000);
+
+    const malformedWindow = makeGhostPage({
+        hostname: 'www.facebook.com',
+        pathname: '/',
+        href: 'https://www.facebook.com/'
+    });
+    const completeMalformedSource = makeFrame('{}\r\u0000');
+    const malformedFrame = completeMalformedSource.slice(0, completeMalformedSource.byteLength - 1);
+    const malformedOriginal = Array.from(malformedFrame);
+    const malformed = websocketSend(
+        malformedWindow,
+        malformedFrame,
+        'wss://edge-chat.facebook.com/chat?region=redacted'
+    );
+    assert.strictEqual(malformed.result, undefined, 'truncated queue-send frames with Seen metadata must fail closed');
+    assert.strictEqual(malformed.socket.sent.length, 0);
+    assert.deepStrictEqual(Array.from(malformedFrame), malformedOriginal);
 }
 
 async function testFacebookSecureEncryptedDirectRecipientSendsAreAllowed() {
@@ -1831,11 +2326,11 @@ async function testFacebookSecureEncryptedDirectRecipientSendsAreAllowed() {
     );
     assert.strictEqual(outcome.postCount, 1);
     assert.strictEqual(outcome.blocked, 0);
-    assert.strictEqual(outcome.sanitized, 0);
+    assert.strictEqual(outcome.sanitized, 1);
     const forwarded = parseForwardedMessage(outcome.post);
-    assert.strictEqual(forwarded.tasks.length, 2);
+    assert.strictEqual(forwarded.tasks.length, 1);
     assert.strictEqual(forwarded.tasks[0].label, '46');
-    assert.strictEqual(forwarded.tasks[1].label, 'sendChatStateFromComposer');
+    assert.strictEqual(JSON.parse(forwarded.tasks[0].payload).encrypted_message, 'redacted-ciphertext');
 }
 
 function testMessengerPatchMixedSendReadStringBatchPreservesSend() {
@@ -9016,9 +9511,11 @@ async function testMessageRequestClickGraceKeepsTransportAndBridgeNative() {
     testMessengerPatchMixedSendTypingBatchPreservesSend();
     testFacebookPatchMixedSendTypingBatchPreservesSend();
     testFacebookMiniChatSecureSendWithAlternateTargetsIsForwarded();
-    testFacebookMiniChatMixedSendTypingBridgeFrameDoesNotEnterTypingSanitizer();
+    testFacebookMiniChatQueueDirectSendSanitizesBundledPrivacy();
     testFacebookGroupSendWithQueueOnlyTargetPreservesSendAndRemovesTyping();
+    testFacebookQueueOnlyGroupUserContentDoesNotTriggerPrivacyBlock();
     testFacebookQueueOnlyPrivacyTasksAreNotClassifiedAsSends();
+    testFacebookQueueOnlyGroupSendWithSeenMetadataIsAllowedOnRealtimeWebSocket();
     await testFacebookSecureEncryptedDirectRecipientSendsAreAllowed();
     testMessengerPatchMixedSendReadStringBatchPreservesSend();
     testMessengerPatchObjectMapBatchSanitizesPrivacyTasks();


### PR DESCRIPTION
## Summary

- preserve queue-routed Facebook group-message sends across WebSocket, Worker, and MessagePort paths
- remove bundled typing and Seen metadata without changing message content or exact 64-bit routing identifiers
- expand regression coverage and document the fix for the unreleased v2.0.7 package

## Root cause

The earlier safeguard covered older and mixed Messenger task batches but did not fully handle Meta's current label-46, single-task, queue-routed send envelopes. Privacy metadata bundled into those envelopes could therefore cause the valid send to be dropped and leave the message stuck in Sending.

## Validation

- `npm ci`
- `npm run ci`
- Chromium, Edge, and Firefox package creation and archive inspection
- live Facebook verification in four authorized group chats, including reload persistence and recipient confirmation

Related to #145.