### PR TITLE
fix(ui): warn about Facebook group chat send limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ section, and GitHub Releases should match the facts recorded here.
 The format follows the spirit of Keep a Changelog: human-written entries,
 grouped by version, with the most recent changes first.
 
+## [2.0.9] - 2026-08-29
+
+### Added
+
+- Added a compact popup warning beside Facebook/Messenger Hide Seen for the
+  known Facebook.com group-chat sending issue, with a workaround to use
+  messenger.com or turn Hide Seen off and refresh.
+
 ## [2.0.8] - 2026-08-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ section, and GitHub Releases should match the facts recorded here.
 The format follows the spirit of Keep a Changelog: human-written entries,
 grouped by version, with the most recent changes first.
 
+## [2.0.10] - 2026-08-29
+
+### Added
+
+- Added a compact popup warning beside Facebook/Messenger Hide Seen for the
+  known Facebook.com group-chat sending issue, with a workaround to use
+  messenger.com or turn Hide Seen off and refresh.
+
+### Fixed
+
+- Fixed the Facebook/Messenger Hide Seen switch so clicking the visible toggle
+  changes the setting.
+
 ## [2.0.9] - 2026-08-29
 
 ### Added

--- a/dist/config/patterns.json
+++ b/dist/config/patterns.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.9",
+    "version": "2.0.10",
     "killSwitch": [],
     "patterns": {
         "igTyping": [

--- a/dist/config/patterns.json
+++ b/dist/config/patterns.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.8",
+    "version": "2.0.9",
     "killSwitch": [],
     "patterns": {
         "igTyping": [

--- a/dist/css/popup.css
+++ b/dist/css/popup.css
@@ -261,6 +261,8 @@ a {
     .header h1,
     .header-verification,
     .status-tooltip,
+    .warning-trigger,
+    .warning-tooltip,
     .feature-icon {
         transition-duration: 0.01ms;
     }
@@ -402,6 +404,8 @@ a {
 .row-label {
     display: inline-flex;
     align-items: center;
+    flex: 1 1 auto;
+    min-width: 0;
     gap: 9px;
     color: var(--ghost-text);
     font-size: 13px;
@@ -434,6 +438,96 @@ a {
 .row:hover .feature-icon {
     color: #c7b9ff;
     transform: translateY(-0.5px) scale(1.05);
+}
+
+.warning-trigger {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    flex: 0 0 auto;
+    margin-right: 8px;
+    padding: 0;
+    border: 1px solid rgba(201, 139, 32, 0.7);
+    border-radius: 50%;
+    color: #e2b653;
+    background: rgba(201, 139, 32, 0.1);
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1;
+    cursor: help;
+    transition: color 140ms ease, border-color 140ms ease, background 140ms ease;
+}
+
+.warning-trigger[hidden] {
+    display: none;
+}
+
+.warning-trigger:hover,
+.warning-trigger:focus-visible {
+    color: #f2cf72;
+    border-color: rgba(201, 139, 32, 0.95);
+    background: rgba(201, 139, 32, 0.18);
+}
+
+.warning-trigger:focus-visible {
+    outline: 2px solid rgba(170, 152, 238, 0.72);
+    outline-offset: 2px;
+}
+
+.warning-tooltip {
+    position: absolute;
+    top: calc(100% + 7px);
+    right: 0;
+    z-index: 30;
+    width: max-content;
+    max-width: min(250px, calc(100vw - 24px));
+    padding: 8px 10px;
+    border: 1px solid rgba(201, 139, 32, 0.52);
+    border-radius: 8px;
+    color: #f0ece4;
+    background:
+        linear-gradient(135deg, rgba(201, 139, 32, 0.08), transparent 48%),
+        #0e0e0d;
+    box-shadow: 0 10px 22px rgba(0, 0, 0, 0.42);
+    font-size: 11px;
+    font-weight: 500;
+    line-height: 1.35;
+    letter-spacing: 0;
+    text-align: center;
+    text-wrap: balance;
+    white-space: normal;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translateY(-3px);
+    transition:
+        opacity 140ms ease,
+        visibility 0s linear 140ms,
+        transform 140ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.warning-tooltip::before {
+    content: "";
+    position: absolute;
+    right: 7px;
+    bottom: 100%;
+    width: 9px;
+    height: 9px;
+    border-left: 1px solid rgba(201, 139, 32, 0.52);
+    border-top: 1px solid rgba(201, 139, 32, 0.52);
+    background: #17150f;
+    transform: translateY(5px) rotate(45deg);
+}
+
+.warning-trigger:hover .warning-tooltip,
+.warning-trigger:focus .warning-tooltip {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+    transition-delay: 0s;
 }
 
 /* ── Toggle switch ────────────────────────────── */

--- a/dist/js/content.js
+++ b/dist/js/content.js
@@ -75,7 +75,7 @@
 
   // src/content.js
   var FALLBACK_CONFIG = {
-    version: "2.0.9",
+    version: "2.0.10",
     killSwitch: [],
     patterns: {
       igTyping: [

--- a/dist/js/content.js
+++ b/dist/js/content.js
@@ -75,7 +75,7 @@
 
   // src/content.js
   var FALLBACK_CONFIG = {
-    version: "2.0.8",
+    version: "2.0.9",
     killSwitch: [],
     patterns: {
       igTyping: [

--- a/dist/js/popup.js
+++ b/dist/js/popup.js
@@ -59,6 +59,7 @@ function loadSettings() {
                 element.checked = settings[settingKey];
             }
         });
+        updateMessengerSeenWarning(Boolean(settings.msgSeen));
     });
 }
 
@@ -68,8 +69,18 @@ function attachEventListeners() {
     inputs.forEach(input => {
         input.addEventListener('change', () => {
             saveSettings();
+            if (input.id === SETTING_INPUT_IDS.msgSeen) {
+                updateMessengerSeenWarning(input.checked);
+            }
         });
     });
+}
+
+function updateMessengerSeenWarning(isEnabled) {
+    const warningElement = document.getElementById('msg-seen-warning');
+    if (warningElement) {
+        warningElement.hidden = !isEnabled;
+    }
 }
 
 function saveSettings() {

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Ghostify | Hide Seen, Typing & Story Views",
-    "version": "2.0.8",
+    "version": "2.0.9",
     "description": "Control your visibility on Instagram & Facebook/Messenger. Hide typing indicators, read receipts, and story views.",
     "author": "Hendrizzzz",
     "permissions": [

--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Ghostify | Hide Seen, Typing & Story Views",
-    "version": "2.0.9",
+    "version": "2.0.10",
     "description": "Control your visibility on Instagram & Facebook/Messenger. Hide typing indicators, read receipts, and story views.",
     "author": "Hendrizzzz",
     "permissions": [

--- a/dist/popup.html
+++ b/dist/popup.html
@@ -96,13 +96,17 @@
                     </span>
                 </div>
                 <div class="card">
-                    <label class="row">
-                        <span class="row-label">
+                    <div class="row">
+                        <label class="row-label" for="msg-seen">
                             <svg class="feature-icon seen-icon" aria-hidden="true"><use href="#feature-seen"></use></svg>
                             <span>Hide Seen</span>
-                        </span>
+                        </label>
+                        <button type="button" class="warning-trigger" id="msg-seen-warning" aria-label="Facebook group chat sending warning" aria-describedby="msg-seen-warning-tooltip" hidden>
+                            <span aria-hidden="true">!</span>
+                            <span class="warning-tooltip" id="msg-seen-warning-tooltip" role="tooltip">Facebook.com group chats may not send with Hide Seen on. Use messenger.com or turn Hide Seen off and refresh.</span>
+                        </button>
                         <span class="switch"><input type="checkbox" id="msg-seen" aria-label="Hide Messenger and Facebook seen receipts"><span class="track"></span></span>
-                    </label>
+                    </div>
                     <label class="row">
                         <span class="row-label">
                             <svg class="feature-icon typing-icon" aria-hidden="true"><use href="#feature-typing"></use></svg>

--- a/dist/popup.html
+++ b/dist/popup.html
@@ -105,7 +105,7 @@
                             <span aria-hidden="true">!</span>
                             <span class="warning-tooltip" id="msg-seen-warning-tooltip" role="tooltip">Facebook.com group chats may not send with Hide Seen on. Use messenger.com or turn Hide Seen off and refresh. Developer help is appreciated.</span>
                         </button>
-                        <span class="switch"><input type="checkbox" id="msg-seen" aria-label="Hide Messenger and Facebook seen receipts"><span class="track"></span></span>
+                        <label class="switch"><input type="checkbox" id="msg-seen" aria-label="Hide Messenger and Facebook seen receipts"><span class="track"></span></label>
                     </div>
                     <label class="row">
                         <span class="row-label">

--- a/dist/popup.html
+++ b/dist/popup.html
@@ -103,7 +103,7 @@
                         </label>
                         <button type="button" class="warning-trigger" id="msg-seen-warning" aria-label="Facebook group chat sending warning" aria-describedby="msg-seen-warning-tooltip" hidden>
                             <span aria-hidden="true">!</span>
-                            <span class="warning-tooltip" id="msg-seen-warning-tooltip" role="tooltip">Facebook.com group chats may not send with Hide Seen on. Use messenger.com or turn Hide Seen off and refresh.</span>
+                            <span class="warning-tooltip" id="msg-seen-warning-tooltip" role="tooltip">Facebook.com group chats may not send with Hide Seen on. Use messenger.com or turn Hide Seen off and refresh. Developer help is appreciated.</span>
                         </button>
                         <span class="switch"><input type="checkbox" id="msg-seen" aria-label="Hide Messenger and Facebook seen receipts"><span class="track"></span></span>
                     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghostify",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghostify",
-      "version": "2.0.8",
+      "version": "2.0.9",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ghostify",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ghostify",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.39.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghostify",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "private": true,
   "description": "Privacy controls for Instagram, Facebook, and Messenger.",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ghostify",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": true,
   "description": "Privacy controls for Instagram, Facebook, and Messenger.",
   "scripts": {

--- a/site/src/app/statusData.json
+++ b/site/src/app/statusData.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "product": "Ghostify",
-  "productVersion": "2.0.9",
+  "productVersion": "2.0.10",
   "generatedAt": "2026-08-28T11:19:24Z",
   "release": {
     "channel": "Chrome Web Store",

--- a/site/src/app/statusData.json
+++ b/site/src/app/statusData.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "product": "Ghostify",
-  "productVersion": "2.0.8",
+  "productVersion": "2.0.9",
   "generatedAt": "2026-08-28T11:19:24Z",
   "release": {
     "channel": "Chrome Web Store",

--- a/src/content.js
+++ b/src/content.js
@@ -5,7 +5,7 @@ import {
 import { normalizePackagedConfig } from "./runtime-config.js";
 
 const FALLBACK_CONFIG = {
-    version: "2.0.8",
+    version: "2.0.9",
     killSwitch: [],
     patterns: {
         igTyping: [

--- a/src/content.js
+++ b/src/content.js
@@ -5,7 +5,7 @@ import {
 import { normalizePackagedConfig } from "./runtime-config.js";
 
 const FALLBACK_CONFIG = {
-    version: "2.0.9",
+    version: "2.0.10",
     killSwitch: [],
     patterns: {
         igTyping: [

--- a/test/messenger-send-stability.test.js
+++ b/test/messenger-send-stability.test.js
@@ -12149,11 +12149,14 @@ function testFacebookNormalConversationClicksDoNotInheritSiblingMessageRequestTe
     );
 }
 
-function testPopupMessengerSeenNoteIsRemoved() {
+function testPopupMessengerSeenWarning() {
     const popupHtml = fs.readFileSync("dist/popup.html", "utf8");
     const popupCss = fs.readFileSync("dist/css/popup.css", "utf8");
+    const popupJs = fs.readFileSync("dist/js/popup.js", "utf8");
     const note =
         "Facebook’s unread UI bug is fixed. If an unread chat still gets marked as read with Hide Seen on, let us know.";
+    const warning =
+        "Facebook.com group chats may not send with Hide Seen on. Use messenger.com or turn Hide Seen off and refresh.";
 
     assert(
         !popupHtml.includes(note),
@@ -12173,9 +12176,58 @@ function testPopupMessengerSeenNoteIsRemoved() {
         "Messenger/Facebook Hide Seen tooltip should avoid technical verification language",
     );
     assert(
-        !popupCss.includes(".info-icon") &&
-            !popupHtml.includes('class="info-icon"'),
-        "Messenger/Facebook Hide Seen should not keep unused info-button styling or markup",
+        popupHtml.includes('id="msg-seen-warning"') &&
+            popupHtml.includes('aria-describedby="msg-seen-warning-tooltip"') &&
+            popupHtml.includes('id="msg-seen-warning-tooltip"') &&
+            popupHtml.includes('role="tooltip"') &&
+            popupHtml.includes(warning) &&
+            popupHtml.includes(" hidden>"),
+        "Messenger/Facebook Hide Seen should expose a compact hidden group-chat warning",
+    );
+    assert(
+        popupCss.includes(".warning-trigger") &&
+            popupCss.includes(".warning-trigger:hover .warning-tooltip") &&
+            popupCss.includes(".warning-trigger:focus .warning-tooltip") &&
+            popupCss.includes("max-width: min(250px, calc(100vw - 24px));") &&
+            popupCss.includes("z-index: 30;") &&
+            popupCss.includes("--status-yellow: #c98b20;") &&
+            !popupCss.includes("--status-red"),
+        "Messenger/Facebook Hide Seen warning should use a compact amber custom tooltip",
+    );
+    assert(
+        popupJs.includes("updateMessengerSeenWarning") &&
+            popupJs.includes("Boolean(settings.msgSeen)") &&
+            popupJs.includes("input.id === SETTING_INPUT_IDS.msgSeen"),
+        "Messenger/Facebook Hide Seen warning should follow the shared toggle",
+    );
+}
+
+function testPopupMessengerSeenWarningFollowsSetting() {
+    const popupSource = fs.readFileSync("dist/js/popup.js", "utf8");
+    const warningElement = { hidden: true };
+    const context = {
+        document: {
+            addEventListener() {},
+            getElementById(id) {
+                return id === "msg-seen-warning" ? warningElement : null;
+            },
+        },
+        window: null,
+    };
+    context.window = context;
+    vm.runInNewContext(popupSource, context, { filename: "popup.js" });
+
+    context.updateMessengerSeenWarning(true);
+    assert.strictEqual(
+        warningElement.hidden,
+        false,
+        "Messenger/Facebook Hide Seen warning should show when Hide Seen is enabled",
+    );
+    context.updateMessengerSeenWarning(false);
+    assert.strictEqual(
+        warningElement.hidden,
+        true,
+        "Messenger/Facebook Hide Seen warning should hide when Hide Seen is disabled",
     );
 }
 
@@ -12960,7 +13012,8 @@ async function testMessageRequestClickGraceKeepsTransportAndBridgeNative() {
     testMessageRequestClicksTemporarilyRestoreNativeFocus();
     testFacebookNestedMessageRequestClicksTemporarilyRestoreNativeFocus();
     testFacebookNormalConversationClicksDoNotInheritSiblingMessageRequestText();
-    testPopupMessengerSeenNoteIsRemoved();
+    testPopupMessengerSeenWarning();
+    testPopupMessengerSeenWarningFollowsSetting();
     testPopupSupportLinksUseGuidedIssueForms();
     testLocalStatusCheckerIsRemovedFromPopupRuntime();
     testPopupPublicStatusSummaryUsesWorkingProofDate();

--- a/test/messenger-send-stability.test.js
+++ b/test/messenger-send-stability.test.js
@@ -12156,7 +12156,7 @@ function testPopupMessengerSeenWarning() {
     const note =
         "Facebook’s unread UI bug is fixed. If an unread chat still gets marked as read with Hide Seen on, let us know.";
     const warning =
-        "Facebook.com group chats may not send with Hide Seen on. Use messenger.com or turn Hide Seen off and refresh.";
+        "Facebook.com group chats may not send with Hide Seen on. Use messenger.com or turn Hide Seen off and refresh. Developer help is appreciated.";
 
     assert(
         !popupHtml.includes(note),

--- a/test/messenger-send-stability.test.js
+++ b/test/messenger-send-stability.test.js
@@ -12185,6 +12185,12 @@ function testPopupMessengerSeenWarning() {
         "Messenger/Facebook Hide Seen should expose a compact hidden group-chat warning",
     );
     assert(
+        popupHtml.includes(
+            '<label class="switch"><input type="checkbox" id="msg-seen"',
+        ),
+        "Messenger/Facebook Hide Seen visible switch should activate its checkbox",
+    );
+    assert(
         popupCss.includes(".warning-trigger") &&
             popupCss.includes(".warning-trigger:hover .warning-tooltip") &&
             popupCss.includes(".warning-trigger:focus .warning-tooltip") &&


### PR DESCRIPTION
## What changed

- Added a small amber `!` warning beside Facebook/Messenger Hide Seen.
- The hover message says Facebook.com group chats may not send with Hide Seen on and gives the workaround: use messenger.com, or turn Hide Seen off, refresh, and resend.
- Fixed the visible Facebook/Messenger Hide Seen switch so clicking the track toggles the setting.
- Prepared the v2.0.10 metadata and release notes for Chromium and Firefox packages.

This is a user-facing mitigation and switch regression fix for #145; the underlying sending bug remains open.

Related to #145

## Checks

- `npm run ci`