### PR TITLE
fix(site): keep 'Ghostify,' brand line clear of its word mask

### DIFF
--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -2782,6 +2782,16 @@
   text-wrap: balance;
 }
 
+/* The brand line splits into masked words (SplitText mask: 'words');
+   its 0.88 line-height clips the italic caps at the mask's top edge,
+   so the mask needs a little breathing room above the glyphs. */
+.home-final-brand,
+.home-final-brand-mask {
+  overflow: visible;
+  padding-top: 0.14em;
+  margin-top: -0.14em;
+}
+
 .home-final-brand {
   width: max-content;
   max-width: 100%;


### PR DESCRIPTION
## Problem
In the closing section, the top of the italic 'Ghostify,' brand line gets clipped (screenshot reported by user). The headline animates via SplitText with `mask: 'words'`; the mask wrapper uses `overflow: clip`, and the brand span's `line-height: 0.88` pulls the italic caps above the mask's top edge.

## Fix
Give `.home-final-brand` and its generated `.home-final-brand-mask` wrapper a small top padding (0.14em) with a matching negative margin, so the glyphs keep their leading without changing line rhythm or layout flow.

## Verification
- Verified in the browser at 1512x860, 1280x800, 834x1112, and 390x844: the 'Ghostify,' line renders fully at every size.
- `npm run typecheck` and `npm run build` pass.