### PR TITLE
fix(site): harden responsive viewport layouts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,12 +35,66 @@ possible.
 ## Submitting Code
 
 1. Fork the repo
-2. Create a branch: `git checkout -b fix/your-fix` or `feature/your-feature`
+2. Create a branch using the [Git naming policy](#git-naming-policy)
 3. Make source changes in `src/` when editing bundled scripts, then run `npm run build`
 4. Edit `dist/` directly only for popup/static assets that do not have a source counterpart
 5. Test on Instagram, Messenger, and Facebook pages affected by the change
 6. Run `npm run ci` before submitting a PR
 7. Submit a PR with a clear description
+
+## Git Naming Policy
+
+Use one shared convention for branches, commits, and pull-request titles. This
+keeps the history readable and ensures the squash commit describes the change
+accurately.
+
+### Branches
+
+Create a short, descriptive lowercase branch using this form:
+
+```text
+<type>/<short-kebab-case-summary>
+```
+
+Use a Conventional Commit type for `<type>`: `feat`, `fix`, `docs`, `chore`,
+`refactor`, `test`, `ci`, `build`, or `perf`. Use only lowercase letters,
+numbers, hyphens, and the single separating slash. Do not prefix a branch with
+a tool, person, or machine name.
+
+Examples:
+
+```text
+fix/responsive-viewport-layout
+feat/firefox-install-guidance
+docs/release-checklist
+```
+
+### Commits and pull-request titles
+
+Use the [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/)
+subject format for every commit and PR title:
+
+```text
+<type>(<optional-scope>): <imperative lowercase summary>
+```
+
+Use a scope when it makes the affected area clearer, such as `site`, `status`,
+`popup`, or `messenger`. A `fix` corrects a bug, while a `feat` adds a
+user-facing capability. Keep the PR title identical to the intended squash
+commit title; merge PRs with **Squash and merge**.
+
+Examples:
+
+```text
+fix(site): harden responsive viewport layouts
+feat(popup): add keyboard shortcut hint
+docs: clarify Firefox release checklist
+```
+
+This repository policy applies GitHub Flow's recommendation for short,
+descriptive branches and GitHub-safe branch characters. It supplements
+Conventional Commits, which standardizes commit subjects but does not prescribe
+branch names.
 
 ## Browser Targets
 

--- a/site/src/app/animation/PlatformsDeck.tsx
+++ b/site/src/app/animation/PlatformsDeck.tsx
@@ -14,13 +14,16 @@ export function PlatformsDeck() {
       const mm = gsap.matchMedia();
 
       mm.add(
-        '(min-width: 1081px) and (pointer: fine) and (prefers-reduced-motion: no-preference)',
+        '(min-width: 1081px) and (min-height: 760px) and (pointer: fine) and (prefers-reduced-motion: no-preference)',
         () => {
           const ctx = gsap.context(() => {
             const section = document.querySelector<HTMLElement>('.platforms-flat');
             if (!section) return;
             const cards = Array.from(section.querySelectorAll<HTMLElement>('.platform-card'));
             if (cards.length < 3) return;
+            // A pin freezes the panel at the viewport top. Fall back to the
+            // normal reveal when a short window cannot show all of its content.
+            if (Math.ceil(section.getBoundingClientRect().height) > window.innerHeight) return;
             const grid = section.querySelector<HTMLElement>('.platform-card-grid');
             const status = section.querySelector<HTMLElement>('.platforms-status');
             const header = section.querySelector<HTMLElement>('.platforms-flat > header');

--- a/site/src/app/components/HomePage.tsx
+++ b/site/src/app/components/HomePage.tsx
@@ -812,7 +812,10 @@ function FeatureScroll() {
     const sectionTop = window.scrollY + section.getBoundingClientRect().top;
     const distance = Math.max(0, section.offsetHeight - window.innerHeight);
     const progress = FEATURES.length === 0 ? 0 : (index + 0.5) / FEATURES.length;
-    window.scrollTo({ top: sectionTop + distance * progress, behavior: 'smooth' });
+    window.scrollTo({
+      top: sectionTop + distance * progress,
+      behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
+    });
   };
 
   return (

--- a/site/src/styles/landing.css
+++ b/site/src/styles/landing.css
@@ -2820,7 +2820,12 @@
   transition-duration: 80ms;
 }
 
-@media (max-width: 1080px), (pointer: coarse) {
+/* Below 688px tall, a fine-pointer desktop uses this complete normal-flow
+   feature list too: its cinematic scene has a 720px minimum and would clip
+   its selector at high Windows/browser display scaling. */
+@media (max-width: 1080px),
+  (pointer: coarse),
+  (min-width: 1081px) and (max-height: 687px) and (pointer: fine) {
   .install-rhythm {
     grid-template-columns: minmax(280px, 0.8fr) minmax(460px, 1.2fr);
     gap: 54px;
@@ -5181,7 +5186,7 @@
   }
 
   .site-root:not(.is-status-view) .platforms-flat.is-dark .platform-card-grid {
-    margin-top: 52px;
+    margin-top: 44px;
   }
 
   .site-root:not(.is-status-view) .platforms-flat.is-dark .platform-card {
@@ -5214,10 +5219,12 @@
   }
 }
 
-/* Compact laptops have enough width for the interactive story, but not enough
-   height for the spacious desktop composition. Keep the same scroll sequence,
-   while grouping its copy, recording, and selector into one compact scene. */
-@media (min-width: 1081px) and (max-width: 1439px) and (pointer: fine) {
+/* Compact and short-window desktops share one resilient feature composition.
+   A short browser viewport can happen at any physical width (for example,
+   1920×1080 with Windows display scaling). Keeping the selector in normal
+   flow here prevents it from covering the verification link. */
+@media (min-width: 1081px) and (max-width: 1439px) and (pointer: fine),
+  (min-width: 1081px) and (max-height: 900px) and (pointer: fine) {
   .site-root:not(.is-status-view) .feature-scroll-sticky {
     padding-top: clamp(48px, 4vw, 64px);
     padding-bottom: clamp(24px, 3vw, 40px);


### PR DESCRIPTION
## What changed

- Prevent the feature selector from covering the verification link in compact and scaled desktop viewports.
- Use the normal-flow feature list when a fine-pointer desktop is too short to display the 720px cinematic scene safely.
- Pin the platform deck only when its complete content fits the viewport.
- Document one branch, commit, PR-title, and squash-title naming policy in `CONTRIBUTING.md`.

## Commands run

- `cd site && npm run typecheck` — passed
- `cd site && npm run build` — passed
- Browser smoke matrix — passed at phone, tablet, laptop, FHD, QHD, and 125%/150%/175%-style effective CSS viewports; no horizontal overflow or console errors.

- [x] `dist/` bundles rebuilt and committed together with `src/` changes (not applicable: no extension `src/` files changed)
- [ ] `npm run ci` passes locally (not run: website-only change; targeted site checks passed)

## Smoke status

- Surfaces touched: marketing site landing page and contributor workflow documentation
- Status: `verified`

## Known risks

- Very short fine-pointer desktop windows intentionally use the readable normal-flow feature list instead of the pinned cinematic scene.