### PR TITLE
fix(status): credit maintainer on daily verification commits

### DIFF
--- a/.github/workflows/daily-verification.yml
+++ b/.github/workflows/daily-verification.yml
@@ -289,6 +289,8 @@ jobs:
           BRANCH: ${{ needs.validate-proposal.outputs.branch }}
           TITLE: ${{ needs.validate-proposal.outputs.title }}
           BASE_SHA: ${{ needs.validate-proposal.outputs.base_sha }}
+          MAINTAINER_NAME: Hendrizzzz
+          MAINTAINER_EMAIL: 139997209+Hendrizzzz@users.noreply.github.com
           GH_TOKEN: ${{ github.token }}
         run: |
           gh auth setup-git
@@ -308,7 +310,7 @@ jobs:
           fi
           git diff --check
           git add site/src/app/statusData.json
-          git commit -m "$TITLE"
+          git commit -m "$TITLE" -m "Co-authored-by: $MAINTAINER_NAME <$MAINTAINER_EMAIL>"
           if [[ "$MODE" == "verified" ]]; then
             git push --force-with-lease --set-upstream origin "$BRANCH"
           else

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,16 @@ in `site/`.
 
 ## Conventions
 
-- Conventional Commits (`fix:`, `feat:`, `chore(status):`, ...); squash-merge PRs.
+- Branch names: `<type>/<short-kebab-description>`, using a standard type such as
+  `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`, `ci/`, `build/`, or
+  `perf/`. Do not prefix branches with an agent, tool, or username.
+- Commit messages: Conventional Commits, `<type>(<optional-scope>): <imperative summary>`
+  (for example, `fix(status): credit maintainer on daily verification commits`).
+- PR titles: use the same Conventional Commit format as commit messages so the
+  squash-merge commit is correctly named (for example, `fix(status): credit maintainer on daily verification commits`).
+- Keep branch names, commit messages, and PR titles specific to one logical change;
+  avoid vague labels such as `update`, `changes`, `misc`, or `fix stuff`.
+- Squash-merge PRs.
 - 4-space indent for extension JS, 2-space for `site/`; Prettier + ESLint run in CI.
   Markdown, YAML, and everything under `.github/` are excluded from Prettier on
   purpose — docs contain validator-pinned phrases.

--- a/test/daily-verification-git.test.js
+++ b/test/daily-verification-git.test.js
@@ -165,6 +165,16 @@ assert(
     "the write-enabled publishing job must not install package dependencies",
 );
 assert(
+    publishJob.includes("MAINTAINER_NAME: Hendrizzzz") &&
+        publishJob.includes(
+            "MAINTAINER_EMAIL: 139997209+Hendrizzzz@users.noreply.github.com",
+        ) &&
+        publishJob.includes(
+            'git commit -m "$TITLE" -m "Co-authored-by: $MAINTAINER_NAME <$MAINTAINER_EMAIL>"',
+        ),
+    "daily status proposal commits must credit the maintainer alongside GitHub Actions",
+);
+assert(
     publishJob.includes(
         "DEPENDENCY_REVIEW_FAILED: ${{ needs.validate-proposal.outputs.dependency_review_failed }}",
     ) &&


### PR DESCRIPTION
The daily Ghostify verification commit now credits Hendrizzzz as a co-author alongside github-actions[bot], using the verified GitHub noreply identity.

This also documents repository-wide conventions for branch names, Conventional Commit messages, and PR titles in AGENTS.md.

Validation: `npm run test:status`